### PR TITLE
Plan AI filter evaluation data delivery

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "traffic:analyze": "tsx script/analyze-vercel-logs.ts",
     "traffic:api": "tsx script/report-api-traffic.ts",
+    "ai-filter-eval:census": "tsx script/collect-ai-filter-eval-census.ts",
     "extract": "lingui extract",
     "compile": "lingui compile",
     "db:generate": "drizzle-kit generate",

--- a/apps/web/script/collect-ai-filter-eval-census.ts
+++ b/apps/web/script/collect-ai-filter-eval-census.ts
@@ -1,0 +1,184 @@
+import { pathToFileURL } from "node:url";
+
+import postgres from "postgres";
+
+import {
+  CensusGuardError,
+  collectWatchlistFilterCensus,
+  isValidCensusAuditIdentifier,
+  serializeCensus,
+  type CensusExecutor,
+  type CensusQuery,
+  type CensusRunContext,
+} from "../src/lib/ai-filter-eval/census";
+
+export const CENSUS_CONFIRMATION_FLAG =
+  "--confirm-read-only-production-census";
+export const CENSUS_DATABASE_ENV = "AI_FILTER_EVAL_DATABASE_URL";
+export const CENSUS_APPROVAL_ID_ENV = "AI_FILTER_EVAL_APPROVAL_ID";
+export const CENSUS_RUN_ID_ENV = "AI_FILTER_EVAL_RUN_ID";
+export const CENSUS_APPROVED_HOST_ENV = "AI_FILTER_EVAL_APPROVED_HOST";
+export const CENSUS_APPROVED_DATABASE_ENV =
+  "AI_FILTER_EVAL_APPROVED_DATABASE";
+export const CENSUS_APPROVED_ROLE_ENV = "AI_FILTER_EVAL_APPROVED_ROLE";
+export const CENSUS_TLS_MODE = "verify-full" as const;
+
+export type CensusInvocation = {
+  databaseUrl: string;
+  approvalId: string;
+  runId: string;
+  approvedHost: string;
+  database: string;
+  role: string;
+};
+
+function requireEnv(
+  env: Readonly<Record<string, string | undefined>>,
+  name: string,
+  maxLength = 200,
+): string {
+  const value = env[name]?.trim();
+  if (!value) throw new CensusGuardError(`${name} must be set`);
+  if (value.length > maxLength || /[\u0000-\u001f\u007f]/.test(value)) {
+    throw new CensusGuardError(`${name} is invalid`);
+  }
+  return value;
+}
+
+export function requireCensusInvocation(
+  argv: readonly string[],
+  env: Readonly<Record<string, string | undefined>>,
+): CensusInvocation {
+  const args = argv.filter((argument) => argument !== "--");
+  if (args.length !== 1 || args[0] !== CENSUS_CONFIRMATION_FLAG) {
+    throw new CensusGuardError(
+      `Refusing census without ${CENSUS_CONFIRMATION_FLAG}`,
+    );
+  }
+
+  const databaseUrl = requireEnv(env, CENSUS_DATABASE_ENV, 4_096);
+  const approvalId = requireEnv(env, CENSUS_APPROVAL_ID_ENV);
+  const runId = requireEnv(env, CENSUS_RUN_ID_ENV);
+  if (!isValidCensusAuditIdentifier(approvalId)) {
+    throw new CensusGuardError(`${CENSUS_APPROVAL_ID_ENV} is invalid`);
+  }
+  if (!isValidCensusAuditIdentifier(runId)) {
+    throw new CensusGuardError(`${CENSUS_RUN_ID_ENV} is invalid`);
+  }
+  const approvedHost = requireEnv(env, CENSUS_APPROVED_HOST_ENV).toLowerCase();
+  const database = requireEnv(env, CENSUS_APPROVED_DATABASE_ENV);
+  const role = requireEnv(env, CENSUS_APPROVED_ROLE_ENV);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    throw new CensusGuardError(`${CENSUS_DATABASE_ENV} must be a valid URL`);
+  }
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    throw new CensusGuardError(
+      `${CENSUS_DATABASE_ENV} must use the PostgreSQL protocol`,
+    );
+  }
+  let dsnDatabase: string;
+  let dsnRole: string;
+  try {
+    if (!/^\/[^/]+$/.test(parsed.pathname)) throw new Error("invalid path");
+    dsnDatabase = decodeURIComponent(parsed.pathname.slice(1));
+    dsnRole = decodeURIComponent(parsed.username);
+  } catch {
+    throw new CensusGuardError(
+      `${CENSUS_DATABASE_ENV} has an invalid database or role`,
+    );
+  }
+  if (
+    parsed.host.toLowerCase() !== approvedHost ||
+    dsnDatabase !== database ||
+    dsnRole !== role
+  ) {
+    throw new CensusGuardError(
+      `${CENSUS_DATABASE_ENV} does not match the approved target`,
+    );
+  }
+  const sslMode = parsed.searchParams.get("sslmode");
+  if (sslMode !== CENSUS_TLS_MODE) {
+    throw new CensusGuardError(
+      `${CENSUS_DATABASE_ENV} must require certificate-verified TLS`,
+    );
+  }
+  return {
+    databaseUrl,
+    approvalId,
+    runId,
+    approvedHost,
+    database,
+    role,
+  };
+}
+
+function createExecutor(databaseUrl: string): {
+  executor: CensusExecutor;
+  close: () => Promise<void>;
+} {
+  const sql = postgres(databaseUrl, {
+    max: 1,
+    prepare: false,
+    idle_timeout: 5,
+    max_lifetime: 60,
+    connection: { application_name: "jobseek-ai-filter-eval-census" },
+    ssl: CENSUS_TLS_MODE,
+  });
+
+  return {
+    executor: {
+      transaction: (work) =>
+        sql.begin(async (transaction) => {
+          const query: CensusQuery = async (statement) => [
+            ...(await transaction.unsafe<Record<string, unknown>[]>(statement)),
+          ];
+          return work(query);
+        }),
+    },
+    close: () => sql.end({ timeout: 5 }),
+  };
+}
+
+function safeFailureMessage(error: unknown): string {
+  return error instanceof CensusGuardError
+    ? error.message
+    : "AI filter evaluation census could not complete";
+}
+
+export async function runCensusCli(
+  argv = process.argv.slice(2),
+  env = process.env,
+): Promise<number> {
+  let connection: ReturnType<typeof createExecutor> | undefined;
+  try {
+    const invocation = requireCensusInvocation(argv, env);
+    connection = createExecutor(invocation.databaseUrl);
+    const context: CensusRunContext = {
+      database: invocation.database,
+      role: invocation.role,
+      approvalId: invocation.approvalId,
+      runId: invocation.runId,
+    };
+    const census = await collectWatchlistFilterCensus(
+      connection.executor,
+      context,
+    );
+    process.stdout.write(serializeCensus(census));
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${safeFailureMessage(error)}\n`);
+    return 1;
+  } finally {
+    await connection?.close().catch(() => undefined);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void runCensusCli().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/apps/web/src/lib/ai-filter-eval/__tests__/census.test.ts
+++ b/apps/web/src/lib/ai-filter-eval/__tests__/census.test.ts
@@ -1,0 +1,559 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CENSUS_COUNT_COLUMNS,
+  CENSUS_FILTER_CLASSIFICATION_RULES,
+  CENSUS_STATEMENT_TIMEOUT_SQL,
+  MINIMUM_RELEASED_CELL_COUNT,
+  READ_ONLY_TRANSACTION_SQL,
+  VERIFY_READ_ONLY_SQL,
+  VERIFY_TABLE_PRIVILEGES_SQL,
+  WATCHLIST_FILTER_CENSUS_SQL,
+  collectWatchlistFilterCensus,
+  serializeCensus,
+  type CensusExecutor,
+  type CensusQuery,
+} from "../census";
+import {
+  CENSUS_APPROVAL_ID_ENV,
+  CENSUS_APPROVED_DATABASE_ENV,
+  CENSUS_APPROVED_HOST_ENV,
+  CENSUS_APPROVED_ROLE_ENV,
+  CENSUS_CONFIRMATION_FLAG,
+  CENSUS_DATABASE_ENV,
+  CENSUS_RUN_ID_ENV,
+  CENSUS_TLS_MODE,
+  requireCensusInvocation,
+} from "../../../../script/collect-ai-filter-eval-census";
+
+const EXPECTED_DATABASE = {
+  database: "jobseek",
+  role: "eval",
+  approvalId: "github-issue-8325-approved",
+  runId: "af2-census-2026-09-11-01",
+} as const;
+const VALID_INVOCATION_ENV = {
+  [CENSUS_DATABASE_ENV]:
+    "postgresql://eval:test@example.test:5432/jobseek?sslmode=verify-full",
+  [CENSUS_APPROVAL_ID_ENV]: EXPECTED_DATABASE.approvalId,
+  [CENSUS_RUN_ID_ENV]: EXPECTED_DATABASE.runId,
+  [CENSUS_APPROVED_HOST_ENV]: "example.test:5432",
+  [CENSUS_APPROVED_DATABASE_ENV]: EXPECTED_DATABASE.database,
+  [CENSUS_APPROVED_ROLE_ENV]: EXPECTED_DATABASE.role,
+} as const;
+
+function aggregateRow(
+  overrides: Record<string, string> = {},
+): Record<string, unknown> {
+  return {
+    population_watchlists: "100",
+    company_scope_any_company: "15",
+    company_scope_explicit_zero: "15",
+    company_scope_explicit_one: "15",
+    company_scope_explicit_two_to_five: "15",
+    company_scope_explicit_six_to_twenty: "20",
+    company_scope_explicit_twenty_one_or_more: "20",
+    filter_dimensions_zero: "20",
+    filter_dimensions_one: "20",
+    filter_dimensions_two: "20",
+    filter_dimensions_three: "20",
+    filter_dimensions_four_or_more: "20",
+    keyword_count_zero: "25",
+    keyword_count_one: "25",
+    keyword_count_two_to_three: "25",
+    keyword_count_four_or_more: "25",
+    filter_presence_location: "40",
+    filter_presence_occupation: "40",
+    filter_presence_seniority: "40",
+    filter_presence_technology: "40",
+    filter_presence_work_mode: "40",
+    filter_presence_employment_type: "40",
+    filter_presence_salary: "40",
+    filter_presence_experience: "40",
+    ...overrides,
+  };
+}
+
+function fakeExecutor(options?: {
+  readOnly?: unknown;
+  defaultReadOnly?: unknown;
+  ssl?: unknown;
+  currentUser?: unknown;
+  currentDatabase?: unknown;
+  hasWritePrivilege?: boolean;
+  roleSuperuser?: boolean;
+  aggregateRows?: readonly Record<string, unknown>[];
+}): { executor: CensusExecutor; statements: string[] } {
+  const statements: string[] = [];
+  const query: CensusQuery = async (statement) => {
+    statements.push(statement);
+    if (statement === READ_ONLY_TRANSACTION_SQL) return [];
+    if (statement === VERIFY_READ_ONLY_SQL) {
+      return [
+        {
+          transaction_read_only: options?.readOnly ?? "on",
+          default_transaction_read_only: options?.defaultReadOnly ?? "on",
+          current_user: options?.currentUser ?? EXPECTED_DATABASE.role,
+          current_database:
+            options?.currentDatabase ?? EXPECTED_DATABASE.database,
+          ssl: options?.ssl ?? true,
+        },
+      ];
+    }
+    if (statement === VERIFY_TABLE_PRIVILEGES_SQL) {
+      return [
+        {
+          role_superuser: options?.roleSuperuser ?? false,
+          role_createdb: false,
+          role_createrole: false,
+          role_replication: false,
+          role_bypassrls: false,
+          database_create: false,
+          public_schema_create: false,
+          watchlist_insert: options?.hasWritePrivilege ?? false,
+          watchlist_update: false,
+          watchlist_delete: false,
+          watchlist_truncate: false,
+          watchlist_trigger: false,
+          watchlist_references: false,
+          watchlist_company_insert: false,
+          watchlist_company_update: false,
+          watchlist_company_delete: false,
+          watchlist_company_truncate: false,
+          watchlist_company_trigger: false,
+          watchlist_company_references: false,
+        },
+      ];
+    }
+    if (statement === CENSUS_STATEMENT_TIMEOUT_SQL) return [];
+    if (statement === WATCHLIST_FILTER_CENSUS_SQL) {
+      return options?.aggregateRows ?? [aggregateRow()];
+    }
+    throw new Error("Unexpected test query");
+  };
+
+  return {
+    statements,
+    executor: {
+      transaction: (work) => work(query),
+    },
+  };
+}
+
+function cell(
+  census: Awaited<ReturnType<typeof collectWatchlistFilterCensus>>,
+  metricName: string,
+  bucket: string,
+) {
+  return census.metrics
+    .find((metric) => metric.name === metricName)
+    ?.buckets.find((candidate) => candidate.bucket === bucket);
+}
+
+describe("AI filter evaluation census", () => {
+  it("requires the dedicated database URL and explicit confirmation", () => {
+    expect(
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], VALID_INVOCATION_ENV),
+    ).toEqual({
+      databaseUrl: VALID_INVOCATION_ENV[CENSUS_DATABASE_ENV],
+      approvalId: VALID_INVOCATION_ENV[CENSUS_APPROVAL_ID_ENV],
+      runId: VALID_INVOCATION_ENV[CENSUS_RUN_ID_ENV],
+      approvedHost: VALID_INVOCATION_ENV[CENSUS_APPROVED_HOST_ENV],
+      database: EXPECTED_DATABASE.database,
+      role: EXPECTED_DATABASE.role,
+    });
+    expect(() =>
+      requireCensusInvocation([], VALID_INVOCATION_ENV),
+    ).toThrow(/confirm-read-only-production-census/);
+    expect(() =>
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], {
+        ...VALID_INVOCATION_ENV,
+        [CENSUS_DATABASE_ENV]: undefined,
+      }),
+    ).toThrow(`${CENSUS_DATABASE_ENV} must be set`);
+    expect(() =>
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], {
+        ...VALID_INVOCATION_ENV,
+        [CENSUS_DATABASE_ENV]: "https://example.test/db",
+      }),
+    ).toThrow(/PostgreSQL protocol/);
+    expect(() =>
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], {
+        ...VALID_INVOCATION_ENV,
+        [CENSUS_APPROVAL_ID_ENV]: undefined,
+      }),
+    ).toThrow(`${CENSUS_APPROVAL_ID_ENV} must be set`);
+    expect(() =>
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], {
+        ...VALID_INVOCATION_ENV,
+        [CENSUS_RUN_ID_ENV]: "run id with spaces",
+      }),
+    ).toThrow(`${CENSUS_RUN_ID_ENV} is invalid`);
+    expect(() =>
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], {
+        ...VALID_INVOCATION_ENV,
+        [CENSUS_DATABASE_ENV]:
+          "postgresql://eval:test@other.example.test:5432/jobseek",
+      }),
+    ).toThrow(/does not match the approved target/);
+    expect(() =>
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], {
+        ...VALID_INVOCATION_ENV,
+        [CENSUS_DATABASE_ENV]:
+          "postgresql://eval:test@example.test:5432/jobseek?sslmode=disable",
+      }),
+    ).toThrow(/certificate-verified TLS/);
+    expect(() =>
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], {
+        ...VALID_INVOCATION_ENV,
+        [CENSUS_DATABASE_ENV]:
+          "postgresql://eval:test@example.test:5432/jobseek?sslmode=require",
+      }),
+    ).toThrow(/certificate-verified TLS/);
+    expect(() =>
+      requireCensusInvocation([CENSUS_CONFIRMATION_FLAG], {
+        ...VALID_INVOCATION_ENV,
+        [CENSUS_DATABASE_ENV]:
+          "postgresql://eval:test@example.test:5432/jobseek",
+      }),
+    ).toThrow(/certificate-verified TLS/);
+    expect(CENSUS_TLS_MODE).toBe("verify-full");
+  });
+
+  it("sets and verifies read-only mode before executing the aggregate query", async () => {
+    const { executor, statements } = fakeExecutor();
+
+    const census = await collectWatchlistFilterCensus(
+      executor,
+      EXPECTED_DATABASE,
+      new Date("2026-09-11T12:00:00.000Z"),
+    );
+
+    expect(statements).toEqual([
+      READ_ONLY_TRANSACTION_SQL,
+      VERIFY_READ_ONLY_SQL,
+      VERIFY_TABLE_PRIVILEGES_SQL,
+      CENSUS_STATEMENT_TIMEOUT_SQL,
+      WATCHLIST_FILTER_CENSUS_SQL,
+    ]);
+    expect(census).toMatchObject({
+      schemaVersion: 2,
+      classificationSemantics: "aggregate_shape_approximation_v1",
+      collectedAt: "2026-09-11T12:00:00.000Z",
+      provenance: {
+        approvalId: EXPECTED_DATABASE.approvalId,
+        runId: EXPECTED_DATABASE.runId,
+      },
+      privacy: {
+        aggregateOnly: true,
+        minimumReleasedCellCount: MINIMUM_RELEASED_CELL_COUNT,
+        readOnlyTransactionVerified: true,
+        populationTotalsReleased: false,
+        complementarySuppression: true,
+        readOnlyCredentialVerified: true,
+      },
+    });
+  });
+
+  it("fails closed before census SQL if transaction_read_only is not on", async () => {
+    const { executor, statements } = fakeExecutor({ readOnly: "off" });
+
+    await expect(
+      collectWatchlistFilterCensus(executor, EXPECTED_DATABASE),
+    ).rejects.toThrow(
+      "Database transaction is not read-only",
+    );
+    expect(statements).toEqual([
+      READ_ONLY_TRANSACTION_SQL,
+      VERIFY_READ_ONLY_SQL,
+    ]);
+  });
+
+  it("rejects invalid provenance before opening a transaction", async () => {
+    const { executor, statements } = fakeExecutor();
+    await expect(
+      collectWatchlistFilterCensus(executor, {
+        ...EXPECTED_DATABASE,
+        runId: "bad run id",
+      }),
+    ).rejects.toThrow("approval or run identifier is invalid");
+    expect(statements).toEqual([]);
+  });
+
+  it("fails closed on TLS, identity, defaults, or write privileges", async () => {
+    await expect(
+      collectWatchlistFilterCensus(
+        fakeExecutor({ ssl: false }).executor,
+        EXPECTED_DATABASE,
+      ),
+    ).rejects.toThrow("not using TLS");
+    await expect(
+      collectWatchlistFilterCensus(
+        fakeExecutor({ currentUser: "writer" }).executor,
+        EXPECTED_DATABASE,
+      ),
+    ).rejects.toThrow("identity does not match approval");
+    await expect(
+      collectWatchlistFilterCensus(
+        fakeExecutor({ defaultReadOnly: "off" }).executor,
+        EXPECTED_DATABASE,
+      ),
+    ).rejects.toThrow("not read-only by default");
+
+    const { executor, statements } = fakeExecutor({
+      hasWritePrivilege: true,
+    });
+    await expect(
+      collectWatchlistFilterCensus(executor, EXPECTED_DATABASE),
+    ).rejects.toThrow("write-capable privileges");
+    expect(statements).toEqual([
+      READ_ONLY_TRANSACTION_SQL,
+      VERIFY_READ_ONLY_SQL,
+      VERIFY_TABLE_PRIVILEGES_SQL,
+    ]);
+    await expect(
+      collectWatchlistFilterCensus(
+        fakeExecutor({ roleSuperuser: true }).executor,
+        EXPECTED_DATABASE,
+      ),
+    ).rejects.toThrow("write-capable privileges");
+  });
+
+  it("applies primary and complementary suppression for one small cell", async () => {
+    const { executor } = fakeExecutor({
+      aggregateRows: [
+        aggregateRow({
+          company_scope_any_company: "5",
+          company_scope_explicit_zero: "25",
+        }),
+      ],
+    });
+    const census = await collectWatchlistFilterCensus(
+      executor,
+      EXPECTED_DATABASE,
+    );
+
+    expect(
+      cell(census, "watchlists_by_company_scope", "any_company"),
+    ).toEqual({
+      bucket: "any_company",
+      count: null,
+      suppressed: true,
+    });
+    expect(
+      cell(census, "watchlists_by_company_scope", "explicit_one"),
+    ).toEqual({
+      bucket: "explicit_one",
+      count: null,
+      suppressed: true,
+    });
+    expect(
+      cell(census, "watchlists_by_filter_dimension_count", "zero"),
+    ).toMatchObject({ count: null, suppressed: true });
+    expect(
+      cell(census, "watchlists_by_filter_dimension_count", "one"),
+    ).toMatchObject({ count: null, suppressed: true });
+    expect(census.metrics.map((metric) => metric.name)).not.toContain(
+      "watchlist_population",
+    );
+  });
+
+  it("keeps multiple small cells hidden without exposing a recoverable total", async () => {
+    const { executor } = fakeExecutor({
+      aggregateRows: [
+        aggregateRow({
+          company_scope_any_company: "4",
+          company_scope_explicit_zero: "6",
+          company_scope_explicit_one: "35",
+        }),
+      ],
+    });
+    const census = await collectWatchlistFilterCensus(
+      executor,
+      EXPECTED_DATABASE,
+    );
+
+    expect(
+      cell(census, "watchlists_by_company_scope", "any_company"),
+    ).toMatchObject({ count: null, suppressed: true });
+    expect(
+      cell(census, "watchlists_by_company_scope", "explicit_zero"),
+    ).toMatchObject({ count: null, suppressed: true });
+    expect(
+      cell(census, "watchlists_by_company_scope", "explicit_one"),
+    ).toMatchObject({ count: 35, suppressed: false });
+    expect(census.metrics.flatMap((metric) => metric.buckets)).not.toContainEqual(
+      expect.objectContaining({ bucket: "all_persisted_watchlists" }),
+    );
+  });
+
+  it("protects a small implied complement in a presence marginal", async () => {
+    const { executor } = fakeExecutor({
+      aggregateRows: [
+        aggregateRow({
+          filter_presence_location: "95",
+        }),
+      ],
+    });
+    const census = await collectWatchlistFilterCensus(
+      executor,
+      EXPECTED_DATABASE,
+    );
+
+    expect(
+      cell(census, "watchlists_by_filter_presence", "location"),
+    ).toMatchObject({ count: null, suppressed: true });
+    expect(
+      cell(census, "watchlists_by_filter_presence", "occupation"),
+    ).toMatchObject({ count: null, suppressed: true });
+  });
+
+  it("emits only fixed ordered metric and bucket labels", async () => {
+    const { executor } = fakeExecutor();
+    const census = await collectWatchlistFilterCensus(
+      executor,
+      EXPECTED_DATABASE,
+    );
+
+    expect(census.metrics.map((metric) => metric.name)).toEqual([
+      "watchlists_by_company_scope",
+      "watchlists_by_filter_dimension_count",
+      "watchlists_by_keyword_count",
+      "watchlists_by_filter_presence",
+    ]);
+    expect(
+      census.metrics.find(
+        (metric) => metric.name === "watchlists_by_company_scope",
+      )?.buckets,
+    ).toEqual([
+      { bucket: "any_company", count: 15, suppressed: false },
+      { bucket: "explicit_zero", count: 15, suppressed: false },
+      { bucket: "explicit_one", count: 15, suppressed: false },
+      { bucket: "explicit_two_to_five", count: 15, suppressed: false },
+      { bucket: "explicit_six_to_twenty", count: 20, suppressed: false },
+      {
+        bucket: "explicit_twenty_one_or_more",
+        count: 20,
+        suppressed: false,
+      },
+    ]);
+  });
+
+  it("rejects aggregate rows with missing, extra, or invalid cells", async () => {
+    const privateKeyword = "staff platform engineer near secret-project";
+    const extra = aggregateRow({ raw_keyword_text: privateKeyword });
+    const missing = aggregateRow();
+    delete missing.population_watchlists;
+
+    await expect(
+      collectWatchlistFilterCensus(
+        fakeExecutor({ aggregateRows: [extra] }).executor,
+        EXPECTED_DATABASE,
+      ),
+    ).rejects.toThrow("unexpected aggregate shape");
+    expect(CENSUS_COUNT_COLUMNS).not.toContain("raw_keyword_text");
+    await expect(
+      collectWatchlistFilterCensus(
+        fakeExecutor({ aggregateRows: [missing] }).executor,
+        EXPECTED_DATABASE,
+      ),
+    ).rejects.toThrow("unexpected aggregate shape");
+    await expect(
+      collectWatchlistFilterCensus(
+        fakeExecutor({
+          aggregateRows: [aggregateRow({ population_watchlists: "9.5" })],
+        }).executor,
+        EXPECTED_DATABASE,
+      ),
+    ).rejects.toThrow("invalid aggregate count");
+    await expect(
+      collectWatchlistFilterCensus(
+        fakeExecutor({
+          aggregateRows: [
+            aggregateRow({ company_scope_any_company: "16" }),
+          ],
+        }).executor,
+        EXPECTED_DATABASE,
+      ),
+    ).rejects.toThrow("inconsistent aggregate counts");
+  });
+
+  it("pins the effective-read-derived classifier without claiming parity", () => {
+    const normalization = CENSUS_FILTER_CLASSIFICATION_RULES;
+
+    expect(normalization).toEqual({
+      keyword: { maxItems: 20, maxLength: 120 },
+      taxonomy: { maxItems: 20, maxLength: 100 },
+      workMode: { maxItems: 3, maxLength: 8 },
+      employmentType: { maxItems: 6, maxLength: 16 },
+      salaryMaximum: 1_000_000_000,
+      experienceMaximum: 15,
+    });
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain(
+      "array_item.item_index <= list_rules.max_items",
+    );
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain(
+      "jsonb_typeof(item.value) = 'string'",
+    );
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain("count(DISTINCT CASE");
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain(
+      "ARRAY['onsite', 'hybrid', 'remote']::text[]",
+    );
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain(
+      "ARRAY['full_time', 'part_time', 'contract', 'internship', 'temporary', 'volunteer']::text[]",
+    );
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain(
+      "salary_min > salary_max THEN 0",
+    );
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain(
+      "experience_min > experience_max THEN 0",
+    );
+    expect(WATCHLIST_FILTER_CENSUS_SQL).not.toContain(
+      "normalizeWatchlistFiltersForRead",
+    );
+  });
+
+  it("serializes deterministically for a fixed collection timestamp", async () => {
+    const collectedAt = new Date("2026-09-11T12:00:00.000Z");
+    const first = await collectWatchlistFilterCensus(
+      fakeExecutor().executor,
+      EXPECTED_DATABASE,
+      collectedAt,
+    );
+    const second = await collectWatchlistFilterCensus(
+      fakeExecutor().executor,
+      EXPECTED_DATABASE,
+      collectedAt,
+    );
+
+    expect(serializeCensus(first)).toBe(serializeCensus(second));
+    expect(serializeCensus(first)).toBe(
+      `${JSON.stringify(first, null, 2)}\n`,
+    );
+  });
+
+  it("contains only transaction controls and aggregate read SQL", () => {
+    const sql = [
+      READ_ONLY_TRANSACTION_SQL,
+      VERIFY_READ_ONLY_SQL,
+      VERIFY_TABLE_PRIVILEGES_SQL,
+      CENSUS_STATEMENT_TIMEOUT_SQL,
+      WATCHLIST_FILTER_CENSUS_SQL,
+    ].join("\n");
+
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain("FROM public.watchlist");
+    expect(WATCHLIST_FILTER_CENSUS_SQL).toContain("public.watchlist_company");
+    expect(WATCHLIST_FILTER_CENSUS_SQL).not.toMatch(
+      /\b(?:insert|update|delete|merge|copy|create|alter|drop|truncate|call|do)\b/i,
+    );
+    expect(sql).not.toMatch(/\b(?:title|description|created_at|updated_at)\b/i);
+    expect(
+      CENSUS_COUNT_COLUMNS.every(
+        (column) =>
+          !/(?:^|_)(?:user_id|watchlist_id|company_id|name|title|description|slug|raw_keyword_text|timestamp)(?:_|$)/.test(
+            column,
+          ),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai-filter-eval/census.ts
+++ b/apps/web/src/lib/ai-filter-eval/census.ts
@@ -1,0 +1,625 @@
+import {
+  EMPLOYMENT_TYPE_VALUES,
+  WORK_MODE_VALUES,
+} from "@/lib/search/types";
+
+export const CENSUS_SCHEMA_VERSION = 2 as const;
+export const MINIMUM_RELEASED_CELL_COUNT = 10;
+
+export const READ_ONLY_TRANSACTION_SQL =
+  "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY";
+export const VERIFY_READ_ONLY_SQL = String.raw`
+SELECT
+  current_setting('transaction_read_only') AS transaction_read_only,
+  current_setting('default_transaction_read_only') AS default_transaction_read_only,
+  current_user AS current_user,
+  current_database() AS current_database,
+  coalesce(
+    (SELECT ssl FROM pg_catalog.pg_stat_ssl WHERE pid = pg_backend_pid()),
+    false
+  ) AS ssl
+`;
+export const VERIFY_TABLE_PRIVILEGES_SQL = String.raw`
+SELECT
+  roles.rolsuper AS role_superuser,
+  roles.rolcreatedb AS role_createdb,
+  roles.rolcreaterole AS role_createrole,
+  roles.rolreplication AS role_replication,
+  roles.rolbypassrls AS role_bypassrls,
+  has_database_privilege(current_user, current_database(), 'CREATE') AS database_create,
+  has_schema_privilege(current_user, 'public', 'CREATE') AS public_schema_create,
+  has_table_privilege(current_user, 'public.watchlist', 'INSERT') AS watchlist_insert,
+  has_table_privilege(current_user, 'public.watchlist', 'UPDATE') AS watchlist_update,
+  has_table_privilege(current_user, 'public.watchlist', 'DELETE') AS watchlist_delete,
+  has_table_privilege(current_user, 'public.watchlist', 'TRUNCATE') AS watchlist_truncate,
+  has_table_privilege(current_user, 'public.watchlist', 'TRIGGER') AS watchlist_trigger,
+  has_table_privilege(current_user, 'public.watchlist', 'REFERENCES') AS watchlist_references,
+  has_table_privilege(current_user, 'public.watchlist_company', 'INSERT') AS watchlist_company_insert,
+  has_table_privilege(current_user, 'public.watchlist_company', 'UPDATE') AS watchlist_company_update,
+  has_table_privilege(current_user, 'public.watchlist_company', 'DELETE') AS watchlist_company_delete,
+  has_table_privilege(current_user, 'public.watchlist_company', 'TRUNCATE') AS watchlist_company_truncate,
+  has_table_privilege(current_user, 'public.watchlist_company', 'TRIGGER') AS watchlist_company_trigger,
+  has_table_privilege(current_user, 'public.watchlist_company', 'REFERENCES') AS watchlist_company_references
+FROM pg_catalog.pg_roles AS roles
+WHERE roles.rolname = current_user
+`;
+export const CENSUS_STATEMENT_TIMEOUT_SQL =
+  "SET LOCAL statement_timeout = '30s'";
+
+/**
+ * Fixed aggregate-classification rules derived from the effective read path.
+ * Keeping them exported makes the SQL contract easy to inspect and pin.
+ */
+export const CENSUS_FILTER_CLASSIFICATION_RULES = {
+  keyword: { maxItems: 20, maxLength: 120 },
+  taxonomy: { maxItems: 20, maxLength: 100 },
+  workMode: { maxItems: WORK_MODE_VALUES.length, maxLength: 8 },
+  employmentType: {
+    maxItems: EMPLOYMENT_TYPE_VALUES.length,
+    maxLength: 16,
+  },
+  salaryMaximum: 1_000_000_000,
+  experienceMaximum: 15,
+} as const;
+
+function sqlTextArray(values: readonly string[]): string {
+  return `ARRAY[${values.map((value) => `'${value.replaceAll("'", "''")}'`).join(", ")}]::text[]`;
+}
+
+const rules = CENSUS_FILTER_CLASSIFICATION_RULES;
+const workModesSql = sqlTextArray(WORK_MODE_VALUES);
+const employmentTypesSql = sqlTextArray(EMPLOYMENT_TYPE_VALUES);
+
+/**
+ * One aggregate row crosses the database boundary. Per-watchlist identifiers
+ * and filter values exist only in PostgreSQL CTEs and are never returned.
+ *
+ * This is an aggregate shape classifier, not a compatibility implementation
+ * of normalizeWatchlistFiltersForRead. It follows the material effective-read
+ * rules (bounded leading items, validation, deduplication, public enums,
+ * bounded numeric ranges, and reversed-range removal). PostgreSQL trim,
+ * character length, case-folding, and POSIX Unicode classes can differ from
+ * JavaScript on unusual Unicode input. Candidate extraction must therefore
+ * use the application normalizer; this census is only for stratification.
+ */
+export const WATCHLIST_FILTER_CENSUS_SQL = String.raw`
+WITH list_rules(
+  field_name,
+  max_items,
+  max_length,
+  case_insensitive,
+  slug_only,
+  allowed_values
+) AS (
+  VALUES
+    ('keywords', ${rules.keyword.maxItems}, ${rules.keyword.maxLength}, true, false, NULL::text[]),
+    ('locationSlugs', ${rules.taxonomy.maxItems}, ${rules.taxonomy.maxLength}, false, true, NULL::text[]),
+    ('occupationSlugs', ${rules.taxonomy.maxItems}, ${rules.taxonomy.maxLength}, false, true, NULL::text[]),
+    ('senioritySlugs', ${rules.taxonomy.maxItems}, ${rules.taxonomy.maxLength}, false, true, NULL::text[]),
+    ('technologySlugs', ${rules.taxonomy.maxItems}, ${rules.taxonomy.maxLength}, false, true, NULL::text[]),
+    ('workMode', ${rules.workMode.maxItems}, ${rules.workMode.maxLength}, false, false, ${workModesSql}),
+    ('employmentType', ${rules.employmentType.maxItems}, ${rules.employmentType.maxLength}, false, false, ${employmentTypesSql})
+),
+company_counts AS (
+  SELECT
+    watchlist_id,
+    count(*)::integer AS company_count
+  FROM public.watchlist_company
+  GROUP BY watchlist_id
+),
+watchlist_shapes AS (
+  SELECT
+    w.id AS watchlist_id,
+    CASE
+      WHEN jsonb_typeof(w.filters) = 'object' THEN w.filters
+      ELSE '{}'::jsonb
+    END AS filters,
+    coalesce(company_counts.company_count, 0) AS company_count
+  FROM public.watchlist AS w
+  LEFT JOIN company_counts ON company_counts.watchlist_id = w.id
+),
+list_counts_long AS (
+  SELECT
+    watchlist_shapes.watchlist_id,
+    list_rules.field_name,
+    count(DISTINCT CASE
+      WHEN jsonb_typeof(item.value) = 'string'
+        AND char_length(item.normalized) BETWEEN 1 AND list_rules.max_length
+        AND regexp_replace(item.normalized, E'[\\t\\n\\r]', '', 'g') !~ '[[:cntrl:]]'
+        AND (
+          NOT list_rules.slug_only
+          OR item.normalized ~ '^[[:alnum:]][[:alnum:]._-]*$'
+        )
+        AND (
+          list_rules.allowed_values IS NULL
+          OR item.normalized = ANY(list_rules.allowed_values)
+        )
+      THEN CASE
+        WHEN list_rules.case_insensitive THEN lower(item.normalized)
+        ELSE item.normalized
+      END
+    END)::integer AS item_count
+  FROM watchlist_shapes
+  CROSS JOIN list_rules
+  LEFT JOIN LATERAL (
+    SELECT
+      array_item.value,
+      btrim(array_item.value #>> '{}', E' \\t\\n\\r\\f\\v') AS normalized
+    FROM jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(watchlist_shapes.filters -> list_rules.field_name) = 'array'
+          THEN watchlist_shapes.filters -> list_rules.field_name
+        ELSE '[]'::jsonb
+      END
+    ) WITH ORDINALITY AS array_item(value, item_index)
+    WHERE array_item.item_index <= list_rules.max_items
+  ) AS item ON true
+  GROUP BY watchlist_shapes.watchlist_id, list_rules.field_name
+),
+list_counts AS (
+  SELECT
+    watchlist_id,
+    max(item_count) FILTER (WHERE field_name = 'keywords') AS keyword_count,
+    max(item_count) FILTER (WHERE field_name = 'locationSlugs') AS location_count,
+    max(item_count) FILTER (WHERE field_name = 'occupationSlugs') AS occupation_count,
+    max(item_count) FILTER (WHERE field_name = 'senioritySlugs') AS seniority_count,
+    max(item_count) FILTER (WHERE field_name = 'technologySlugs') AS technology_count,
+    max(item_count) FILTER (WHERE field_name = 'workMode') AS work_mode_count,
+    max(item_count) FILTER (WHERE field_name = 'employmentType') AS employment_type_count
+  FROM list_counts_long
+  GROUP BY watchlist_id
+),
+normalized_ranges AS (
+  SELECT
+    watchlist_shapes.*,
+    CASE
+      WHEN jsonb_typeof(filters -> 'salaryMin') = 'number'
+        AND (filters ->> 'salaryMin')::numeric BETWEEN 0 AND ${rules.salaryMaximum}
+        THEN (filters ->> 'salaryMin')::numeric
+    END AS salary_min,
+    CASE
+      WHEN jsonb_typeof(filters -> 'salaryMax') = 'number'
+        AND (filters ->> 'salaryMax')::numeric BETWEEN 0 AND ${rules.salaryMaximum}
+        THEN (filters ->> 'salaryMax')::numeric
+    END AS salary_max,
+    CASE
+      WHEN jsonb_typeof(filters -> 'experienceMin') = 'number'
+        AND (filters ->> 'experienceMin')::numeric BETWEEN 0 AND ${rules.experienceMaximum}
+        AND (filters ->> 'experienceMin')::numeric = trunc((filters ->> 'experienceMin')::numeric)
+        THEN (filters ->> 'experienceMin')::numeric
+    END AS experience_min,
+    CASE
+      WHEN jsonb_typeof(filters -> 'experienceMax') = 'number'
+        AND (filters ->> 'experienceMax')::numeric BETWEEN 0 AND ${rules.experienceMaximum}
+        AND (filters ->> 'experienceMax')::numeric = trunc((filters ->> 'experienceMax')::numeric)
+        THEN (filters ->> 'experienceMax')::numeric
+    END AS experience_max
+  FROM watchlist_shapes
+),
+classified AS (
+  SELECT
+    normalized_ranges.company_count,
+    normalized_ranges.filters @> '{"anyCompany": true}'::jsonb AS any_company,
+    coalesce(list_counts.keyword_count, 0) AS keyword_count,
+    CASE WHEN coalesce(list_counts.keyword_count, 0) > 0 THEN 1 ELSE 0 END AS has_keywords,
+    CASE WHEN coalesce(list_counts.location_count, 0) > 0 THEN 1 ELSE 0 END AS has_location,
+    CASE WHEN coalesce(list_counts.occupation_count, 0) > 0 THEN 1 ELSE 0 END AS has_occupation,
+    CASE WHEN coalesce(list_counts.seniority_count, 0) > 0 THEN 1 ELSE 0 END AS has_seniority,
+    CASE WHEN coalesce(list_counts.technology_count, 0) > 0 THEN 1 ELSE 0 END AS has_technology,
+    CASE WHEN coalesce(list_counts.work_mode_count, 0) > 0 THEN 1 ELSE 0 END AS has_work_mode,
+    CASE WHEN coalesce(list_counts.employment_type_count, 0) > 0 THEN 1 ELSE 0 END AS has_employment_type,
+    CASE
+      WHEN salary_min IS NOT NULL AND salary_max IS NOT NULL AND salary_min > salary_max THEN 0
+      WHEN salary_min IS NOT NULL OR salary_max IS NOT NULL THEN 1
+      ELSE 0
+    END AS has_salary,
+    CASE
+      WHEN experience_min IS NOT NULL AND experience_max IS NOT NULL
+        AND experience_min > experience_max THEN 0
+      WHEN experience_min IS NOT NULL OR experience_max IS NOT NULL THEN 1
+      ELSE 0
+    END AS has_experience
+  FROM normalized_ranges
+  LEFT JOIN list_counts ON list_counts.watchlist_id = normalized_ranges.watchlist_id
+),
+scored AS (
+  SELECT
+    *,
+    has_keywords + has_location + has_occupation + has_seniority
+      + has_technology + has_work_mode + has_employment_type
+      + has_salary + has_experience AS filter_dimension_count
+  FROM classified
+)
+SELECT
+  (SELECT count(*)::text FROM scored) AS population_watchlists,
+
+  count(*) FILTER (WHERE any_company)::text AS company_scope_any_company,
+  count(*) FILTER (WHERE NOT any_company AND company_count = 0)::text
+    AS company_scope_explicit_zero,
+  count(*) FILTER (WHERE NOT any_company AND company_count = 1)::text
+    AS company_scope_explicit_one,
+  count(*) FILTER (WHERE NOT any_company AND company_count BETWEEN 2 AND 5)::text
+    AS company_scope_explicit_two_to_five,
+  count(*) FILTER (WHERE NOT any_company AND company_count BETWEEN 6 AND 20)::text
+    AS company_scope_explicit_six_to_twenty,
+  count(*) FILTER (WHERE NOT any_company AND company_count >= 21)::text
+    AS company_scope_explicit_twenty_one_or_more,
+
+  count(*) FILTER (WHERE filter_dimension_count = 0)::text AS filter_dimensions_zero,
+  count(*) FILTER (WHERE filter_dimension_count = 1)::text AS filter_dimensions_one,
+  count(*) FILTER (WHERE filter_dimension_count = 2)::text AS filter_dimensions_two,
+  count(*) FILTER (WHERE filter_dimension_count = 3)::text AS filter_dimensions_three,
+  count(*) FILTER (WHERE filter_dimension_count >= 4)::text AS filter_dimensions_four_or_more,
+
+  count(*) FILTER (WHERE keyword_count = 0)::text AS keyword_count_zero,
+  count(*) FILTER (WHERE keyword_count = 1)::text AS keyword_count_one,
+  count(*) FILTER (WHERE keyword_count BETWEEN 2 AND 3)::text AS keyword_count_two_to_three,
+  count(*) FILTER (WHERE keyword_count >= 4)::text AS keyword_count_four_or_more,
+
+  count(*) FILTER (WHERE has_location = 1)::text AS filter_presence_location,
+  count(*) FILTER (WHERE has_occupation = 1)::text AS filter_presence_occupation,
+  count(*) FILTER (WHERE has_seniority = 1)::text AS filter_presence_seniority,
+  count(*) FILTER (WHERE has_technology = 1)::text AS filter_presence_technology,
+  count(*) FILTER (WHERE has_work_mode = 1)::text AS filter_presence_work_mode,
+  count(*) FILTER (WHERE has_employment_type = 1)::text AS filter_presence_employment_type,
+  count(*) FILTER (WHERE has_salary = 1)::text AS filter_presence_salary,
+  count(*) FILTER (WHERE has_experience = 1)::text AS filter_presence_experience
+FROM scored
+`;
+
+type CensusMetricDefinition = {
+  name: string;
+  exhaustive: boolean;
+  buckets: readonly (readonly [bucket: string, column: string])[];
+};
+
+const CENSUS_METRICS: readonly CensusMetricDefinition[] = [
+  {
+    name: "watchlists_by_company_scope",
+    exhaustive: true,
+    buckets: [
+      ["any_company", "company_scope_any_company"],
+      ["explicit_zero", "company_scope_explicit_zero"],
+      ["explicit_one", "company_scope_explicit_one"],
+      ["explicit_two_to_five", "company_scope_explicit_two_to_five"],
+      ["explicit_six_to_twenty", "company_scope_explicit_six_to_twenty"],
+      [
+        "explicit_twenty_one_or_more",
+        "company_scope_explicit_twenty_one_or_more",
+      ],
+    ],
+  },
+  {
+    name: "watchlists_by_filter_dimension_count",
+    exhaustive: true,
+    buckets: [
+      ["zero", "filter_dimensions_zero"],
+      ["one", "filter_dimensions_one"],
+      ["two", "filter_dimensions_two"],
+      ["three", "filter_dimensions_three"],
+      ["four_or_more", "filter_dimensions_four_or_more"],
+    ],
+  },
+  {
+    name: "watchlists_by_keyword_count",
+    exhaustive: true,
+    buckets: [
+      ["zero", "keyword_count_zero"],
+      ["one", "keyword_count_one"],
+      ["two_to_three", "keyword_count_two_to_three"],
+      ["four_or_more", "keyword_count_four_or_more"],
+    ],
+  },
+  {
+    name: "watchlists_by_filter_presence",
+    exhaustive: false,
+    buckets: [
+      ["location", "filter_presence_location"],
+      ["occupation", "filter_presence_occupation"],
+      ["seniority", "filter_presence_seniority"],
+      ["technology", "filter_presence_technology"],
+      ["work_mode", "filter_presence_work_mode"],
+      ["employment_type", "filter_presence_employment_type"],
+      ["salary", "filter_presence_salary"],
+      ["experience", "filter_presence_experience"],
+    ],
+  },
+] as const;
+
+const POPULATION_COLUMN = "population_watchlists";
+
+export const CENSUS_COUNT_COLUMNS = [
+  POPULATION_COLUMN,
+  ...CENSUS_METRICS.flatMap((metric) =>
+    metric.buckets.map(([, column]) => column),
+  ),
+];
+
+type QueryRow = Record<string, unknown>;
+
+export type CensusQuery = (statement: string) => Promise<readonly QueryRow[]>;
+
+export type CensusExecutor = {
+  transaction: (
+    work: (query: CensusQuery) => Promise<WatchlistFilterCensus>,
+  ) => Promise<WatchlistFilterCensus>;
+};
+
+export type CensusRunContext = {
+  database: string;
+  role: string;
+  approvalId: string;
+  runId: string;
+};
+
+export type CensusCell = {
+  bucket: string;
+  count: number | null;
+  suppressed: boolean;
+};
+
+export type WatchlistFilterCensus = {
+  schemaVersion: typeof CENSUS_SCHEMA_VERSION;
+  classificationSemantics: "aggregate_shape_approximation_v1";
+  collectedAt: string;
+  provenance: {
+    approvalId: string;
+    runId: string;
+  };
+  privacy: {
+    aggregateOnly: true;
+    minimumReleasedCellCount: typeof MINIMUM_RELEASED_CELL_COUNT;
+    readOnlyTransactionVerified: true;
+    populationTotalsReleased: false;
+    complementarySuppression: true;
+    readOnlyCredentialVerified: true;
+  };
+  metrics: Array<{
+    name: string;
+    buckets: CensusCell[];
+  }>;
+};
+
+export class CensusGuardError extends Error {}
+
+export function isValidCensusAuditIdentifier(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$/.test(value);
+}
+
+function parseCount(value: unknown): number {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/.test(value)) {
+    throw new CensusGuardError("Census returned an invalid aggregate count");
+  }
+  const count = Number(value);
+  if (!Number.isSafeInteger(count)) {
+    throw new CensusGuardError("Census returned an invalid aggregate count");
+  }
+  return count;
+}
+
+function assertOnlyExpectedColumns(
+  row: QueryRow,
+  expected: readonly string[],
+): void {
+  const actual = Object.keys(row).sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((column, index) => column !== wanted[index])
+  ) {
+    throw new CensusGuardError("Census returned an unexpected aggregate shape");
+  }
+}
+
+function metricKey(metricName: string, column: string): string {
+  return `${metricName}:${column}`;
+}
+
+function addLowestCountsUntil(
+  suppressed: Set<string>,
+  metric: CensusMetricDefinition,
+  counts: Readonly<Record<string, number>>,
+  target: number,
+): void {
+  const existing = metric.buckets.filter(([, column]) =>
+    suppressed.has(metricKey(metric.name, column)),
+  ).length;
+  if (existing >= target) return;
+
+  const candidates = metric.buckets
+    .filter(
+      ([, column]) => !suppressed.has(metricKey(metric.name, column)),
+    )
+    .map(([, column], index) => ({ column, count: counts[column], index }))
+    .sort((left, right) => left.count - right.count || left.index - right.index);
+
+  for (const candidate of candidates.slice(0, target - existing)) {
+    suppressed.add(metricKey(metric.name, candidate.column));
+  }
+}
+
+function buildSuppressionSet(
+  counts: Readonly<Record<string, number>>,
+): Set<string> {
+  const suppressed = new Set<string>();
+  let sensitive = counts[POPULATION_COLUMN] < MINIMUM_RELEASED_CELL_COUNT;
+
+  for (const metric of CENSUS_METRICS) {
+    const population = counts[POPULATION_COLUMN];
+    for (const [, column] of metric.buckets) {
+      const count = counts[column];
+      const complementIsSmall =
+        !metric.exhaustive &&
+        population - count < MINIMUM_RELEASED_CELL_COUNT;
+      if (count < MINIMUM_RELEASED_CELL_COUNT || complementIsSmall) {
+        suppressed.add(metricKey(metric.name, column));
+        sensitive = true;
+      }
+    }
+  }
+
+  /*
+   * A sensitive cell makes the shared population total sensitive too. Totals
+   * are never emitted, and every same-universe view hides at least two cells,
+   * so neither an exhaustive complement nor another marginal can reconstruct
+   * a primary-suppressed count.
+   */
+  for (const metric of CENSUS_METRICS) {
+    if (sensitive) {
+      addLowestCountsUntil(suppressed, metric, counts, 2);
+    }
+  }
+  return suppressed;
+}
+
+function assertAggregateInvariants(
+  counts: Readonly<Record<string, number>>,
+): void {
+  const population = counts[POPULATION_COLUMN];
+  for (const metric of CENSUS_METRICS) {
+    const metricCounts = metric.buckets.map(([, column]) => counts[column]);
+    if (metricCounts.some((count) => count > population)) {
+      throw new CensusGuardError("Census returned inconsistent aggregate counts");
+    }
+    if (
+      metric.exhaustive &&
+      metricCounts.reduce((total, count) => total + count, 0) !== population
+    ) {
+      throw new CensusGuardError("Census returned inconsistent aggregate counts");
+    }
+  }
+}
+
+function assembleCensus(
+  row: QueryRow,
+  context: CensusRunContext,
+  collectedAt: Date,
+): WatchlistFilterCensus {
+  assertOnlyExpectedColumns(row, CENSUS_COUNT_COLUMNS);
+  const counts = Object.fromEntries(
+    CENSUS_COUNT_COLUMNS.map((column) => [column, parseCount(row[column])]),
+  );
+  assertAggregateInvariants(counts);
+  const suppressed = buildSuppressionSet(counts);
+
+  return {
+    schemaVersion: CENSUS_SCHEMA_VERSION,
+    classificationSemantics: "aggregate_shape_approximation_v1",
+    collectedAt: collectedAt.toISOString(),
+    provenance: {
+      approvalId: context.approvalId,
+      runId: context.runId,
+    },
+    privacy: {
+      aggregateOnly: true,
+      minimumReleasedCellCount: MINIMUM_RELEASED_CELL_COUNT,
+      readOnlyTransactionVerified: true,
+      populationTotalsReleased: false,
+      complementarySuppression: true,
+      readOnlyCredentialVerified: true,
+    },
+    metrics: CENSUS_METRICS.map((metric) => ({
+      name: metric.name,
+      buckets: metric.buckets.map(([bucket, column]) => {
+        const isSuppressed = suppressed.has(metricKey(metric.name, column));
+        return {
+          bucket,
+          count: isSuppressed ? null : counts[column],
+          suppressed: isSuppressed,
+        };
+      }),
+    })),
+  };
+}
+
+function verifyReadOnlyResult(
+  rows: readonly QueryRow[],
+  expected: CensusRunContext,
+): void {
+  if (rows.length !== 1) {
+    throw new CensusGuardError("Could not verify the read-only transaction");
+  }
+  const row = rows[0];
+  assertOnlyExpectedColumns(row, [
+    "transaction_read_only",
+    "default_transaction_read_only",
+    "current_user",
+    "current_database",
+    "ssl",
+  ]);
+  if (
+    row.transaction_read_only !== "on" ||
+    row.default_transaction_read_only !== "on"
+  ) {
+    throw new CensusGuardError("Database transaction is not read-only by default");
+  }
+  if (row.ssl !== true) {
+    throw new CensusGuardError("Database connection is not using TLS");
+  }
+  if (
+    row.current_user !== expected.role ||
+    row.current_database !== expected.database
+  ) {
+    throw new CensusGuardError("Database identity does not match approval");
+  }
+}
+
+function verifyTablePrivileges(rows: readonly QueryRow[]): void {
+  if (rows.length !== 1) {
+    throw new CensusGuardError("Could not verify database table privileges");
+  }
+  const expectedColumns = [
+    "role_superuser",
+    "role_createdb",
+    "role_createrole",
+    "role_replication",
+    "role_bypassrls",
+    "database_create",
+    "public_schema_create",
+    "watchlist_insert",
+    "watchlist_update",
+    "watchlist_delete",
+    "watchlist_truncate",
+    "watchlist_trigger",
+    "watchlist_references",
+    "watchlist_company_insert",
+    "watchlist_company_update",
+    "watchlist_company_delete",
+    "watchlist_company_truncate",
+    "watchlist_company_trigger",
+    "watchlist_company_references",
+  ];
+  const row = rows[0];
+  assertOnlyExpectedColumns(row, expectedColumns);
+  if (expectedColumns.some((column) => row[column] !== false)) {
+    throw new CensusGuardError("Database role has write-capable privileges");
+  }
+}
+
+export async function collectWatchlistFilterCensus(
+  executor: CensusExecutor,
+  context: CensusRunContext,
+  collectedAt = new Date(),
+): Promise<WatchlistFilterCensus> {
+  for (const identifier of [context.approvalId, context.runId]) {
+    if (!isValidCensusAuditIdentifier(identifier)) {
+      throw new CensusGuardError("Census approval or run identifier is invalid");
+    }
+  }
+  return executor.transaction(async (query) => {
+    await query(READ_ONLY_TRANSACTION_SQL);
+    verifyReadOnlyResult(await query(VERIFY_READ_ONLY_SQL), context);
+    verifyTablePrivileges(await query(VERIFY_TABLE_PRIVILEGES_SQL));
+    await query(CENSUS_STATEMENT_TIMEOUT_SQL);
+
+    const rows = await query(WATCHLIST_FILTER_CENSUS_SQL);
+    if (rows.length !== 1) {
+      throw new CensusGuardError("Census did not return one aggregate row");
+    }
+    return assembleCensus(rows[0], context, collectedAt);
+  });
+}
+
+export function serializeCensus(census: WatchlistFilterCensus): string {
+  return `${JSON.stringify(census, null, 2)}\n`;
+}

--- a/docs/19-ai-filter-evaluation-data.md
+++ b/docs/19-ai-filter-evaluation-data.md
@@ -216,6 +216,28 @@ configurations before the 200 pairs are opened for annotation.
 Calibration data is destroyed or quarantined as non-benchmark material after
 the selection record is complete. It must not inflate v1 quality results.
 
+Tune each fleet role independently rather than choosing one global model:
+
+- **prompt generator:** compare candidate model/effort settings on the same
+  eight disposable feeds. The orchestrator blind-scores constraint fidelity,
+  plausibility, persona distinctness, and policy compliance; the later
+  12-card human prompt-sanity pass remains the release check;
+- **primary labeller:** use the 24-32 locked human decisions for binary and
+  ambiguity agreement, repeat consistency, false-accept/false-reject balance,
+  schema validity, latency, and token cost;
+- **adjudicator:** use prebuilt conflicting annotation records over the same
+  disposable pairs and score resolution against the locked human decision; and
+- **final critic:** use synthetic manifests with seeded provenance, leakage,
+  count, blindness, and cohort-reporting defects and measure defect recall plus
+  false alarms.
+
+For each role, the orchestrator spot-checks raw outputs before scores are
+unblinded, records observed failure modes, and may refine the task prompt only
+on disposable examples. After any prompt change, rerun every compared
+configuration on the same clean calibration inputs. Freeze the selected model,
+version, reasoning effort, and task-prompt digest per role before final prompt
+generation or annotation begins.
+
 ## Annotation and adjudication
 
 All 200 pairs are independently labelled twice by agents. A label is binary

--- a/docs/19-ai-filter-evaluation-data.md
+++ b/docs/19-ai-filter-evaluation-data.md
@@ -1,0 +1,365 @@
+# AI-filter evaluation data delivery plan
+
+Status: approved plan for the first evaluation-data delivery. Documentation,
+contract/tooling changes, synthetic tests, and non-production dry runs are
+authorized. A production read remains blocked on the approvals below.
+
+This document turns the broader evaluation direction in
+[24 - Subscriber AI Filter](24-ai-filter.md#evaluation-plan) into a bounded
+first delivery. It does not authorize a production read, a provider call, or
+publication of evaluation content. The 1,000-pair corpus in the broader plan
+is a possible later expansion; the approved first delivery is exactly 200
+pairs.
+
+## Dataset contract
+
+The unit of work is a private **feed-prompt bundle**: one de-identified
+production-derived structured-filter snapshot, one synthetic soft prompt, and
+eight ordered candidate postings. The structured filters establish candidate
+provenance and remain evaluation metadata; they are not classifier input.
+
+The v1 corpus contains:
+
+- 20 distinct canonical structured filters;
+- 25 feed-prompt bundles, with five additional uses of already represented
+  filters allowing prompt variation;
+- exactly eight posting pairs per bundle; and
+- exactly 200 `(soft prompt, posting)` pairs (`25 * 8`).
+
+Every filter, bundle, posting, and pair receives an opaque stable ID. Pair IDs
+are derived from the frozen dataset version, bundle ID, and position, not from
+account IDs or raw content. A posting may occur under more than one prompt, but
+each `(bundle ID, position)` is one distinct pair. Once annotation begins,
+replacement or reordering requires a new dataset version.
+
+Keep two cohorts separate in manifests, review packets, and reports:
+
+- **Production-shaped** bundles preserve a real structured-filter shape,
+  observed candidate base rate, and the first eight eligible candidates in the
+  frozen production order. There is no label-aware selection.
+- **Challenge** bundles deliberately exercise near misses, missing or
+  contradictory evidence, multilingual text, prompt injection, and other
+  hard cases. They must retain source-filter and original-rank provenance, but
+  they are not included when reporting the production-shaped acceptance base
+  rate.
+
+The cohort allocation and challenge selection rules are frozen before any
+labels are visible. Report aggregate and cohort metrics separately; never
+blend challenge cases into a claim about production prevalence.
+
+## Sampling procedure
+
+Sampling is a two-pass operation so the final selector is informed by the
+population without repeatedly exposing production rows:
+
+1. Run the aggregate-only census once. It reports fixed, small-cell-suppressed
+   counts for company scope, filter dimensions, keyword count, and filters in
+   use. It returns no filter values or identifiers.
+2. Freeze a 20-slot allocation across the observed broad/narrow, company-scope,
+   keyword/no-keyword, and simple/compound-filter shapes. Do not create tiny
+   strata merely to satisfy a matrix; collapse unsupported slots before the
+   row-level extraction.
+3. In one approved extraction transaction, consider only active configurations
+   that can produce an eight-posting feed at the fixed UTC cutoff. Select no
+   more than one configuration per account and one per canonical filter
+   fingerprint. Selection inside a slot uses a recorded deterministic keyed
+   rank; account, watchlist, and raw-filter identifiers do not leave the
+   extraction boundary.
+4. Materialize 15 distinct filters as 15 production-shaped bundles. Each keeps
+   the first eight eligible candidates in the pinned total order.
+5. Materialize the other five distinct filters as two challenge bundles each,
+   yielding ten challenge bundles. The two prompts may differ, but their
+   candidate selection rules are predeclared and label-blind. Challenge
+   heuristics may target missing evidence, close lexical matches, multilingual
+   content, contradictions, and prompt-injection text; they may not inspect a
+   fit label or target-model prediction.
+
+This gives `15 * 8 = 120` production-shaped pairs and `5 * 2 * 8 = 80`
+challenge pairs while retaining exactly 20 distinct source-filter
+fingerprints. If the census cannot support that allocation without a privacy
+exception or contrived strata, stop and revise the allocation in #8325 rather
+than quietly substituting rows.
+
+Raw keyword text, when present, may be used only inside the approved boundary
+to reproduce the source candidate feed. Prompt authors receive the generalized
+filter shape and frozen feed, never that text. The private manifest records
+only keyword presence/count plus an approved non-reversible fingerprint if one
+is required for replay validation.
+
+## Required fidelity pins
+
+The extraction manifest must make the sample replayable without silently
+following moving code or data:
+
+- repository commit OID, schema version, UTC extraction cutoff, inclusive and
+  exclusive window bounds, Typesense collection/alias target, and canonical
+  fingerprints of all 20 de-identified filters;
+- exact normalizer file/function, source digest, dependency-lock digest,
+  locale fallback order, included payload fields, Unicode/line-ending rules,
+  HTML-to-text behavior, and 12,000-character text-boundary truncation rule;
+- exact candidate compiler/reader file and function, filter string, search
+  parameters, page size, and candidate-order policy; and
+- ordered posting IDs before and after any challenge selection, plus a digest
+  of each final normalized classifier payload.
+
+The AF-1 total order is `postingFirstSeenAt DESC, candidateId ASC`. Current
+`main` does not yet satisfy it: `order: "newest"` compiles only Typesense
+`sort_by: "first_seen_at:desc"` through
+`buildWatchlistCandidateSearchParams` in
+`apps/web/src/lib/search/watchlist-candidate-query.ts`, so equal-time selection
+can inherit engine insertion/batch rank. AF-8 must add and backfill a compatible
+stable sortable key and prove page-boundary behavior before the row-level
+production extraction. See the
+[#8333 prerequisite record](https://github.com/colophon-group/jobseek/issues/8333#issuecomment-5634953859).
+The extraction must still persist the returned ID sequence and all ranks;
+evaluation replay uses that frozen sequence instead of rerunning a live query.
+At whole-second index precision the eligible retention interval is
+`(cutoff - 30 days, cutoff)`, compiled through the canonical half-open reader
+as `[cutoff - 30 days + 1 second, cutoff)`. A posting exactly at the older
+retention boundary is already expired and is not sampled.
+
+The classifier normalizer is not implicitly the crawler's storage HTML
+normalizer. The tooling PR must designate and test one exact classifier
+normalizer. Sampling is blocked until that artifact is pinned, and a later
+normalizer change creates a new dataset version rather than mutating v1.
+
+## Approval boundary
+
+No agent or operator may read production for this work until all of the
+following are recorded explicitly in the governing issue:
+
+- a privacy decision approving the precise source tables/objects and fields,
+  de-identification and redaction rules, access list, private storage,
+  retention, deletion, and incident handling;
+- a licensing decision approving private evaluation use of the job text and
+  required provenance;
+- a read-only access plan naming the approver, operator, credentials, exact
+  query/tool, time window, row and byte ceilings, audit logging, and expiry;
+  and
+- approval of the synthetic-prompt policy, protected-characteristic boundary,
+  annotation guide, and allowed model processing terms.
+
+Production access is one bounded, logged, read-only extraction. It may not
+write back, update timestamps, create durable production objects, or reuse
+private account identifiers or raw user prompts. Remove account, user,
+watchlist, email, URL-token, and other linkable identifiers before material
+leaves the approved extraction boundary. Raw extracts, prompts, descriptions,
+labels, and review packets stay in approved private storage and are never
+committed or uploaded to the existing public Hugging Face dataset.
+
+This plan originally conflicted with the acceptance policy in
+[#8325](https://github.com/colophon-group/jobseek/issues/8325) and Draft
+[#8498](https://github.com/colophon-group/jobseek/pull/8498), which forbade
+agent-created prompts and/or labels. The human-approved scope correction is now
+recorded in [#8325](https://github.com/colophon-group/jobseek/issues/8325#issuecomment-5634034857)
+and [#8467](https://github.com/colophon-group/jobseek/issues/8467#issuecomment-5634048323).
+The Draft harness implementation and its documentation must still be reconciled
+with that decision before calibration, prompt creation, annotation, or any
+production read.
+
+### Aggregate census runbook
+
+The first approved production action is the aggregate census only. Before an
+operator runs it, the #8325 approval record must contain the approval ID, unique
+run ID, exact TLS endpoint/database/SELECT-only role, operator, output location,
+and confirmation that this is the single permitted snapshot. Reusing a run ID
+or taking a second snapshot requires a new approval; the read-only tool cannot
+truthfully enforce one-shot use with durable state.
+
+From `apps/web`, with a private `umask 077` shell and the output path outside the
+repository, set:
+
+- `AI_FILTER_EVAL_DATABASE_URL`;
+- `AI_FILTER_EVAL_APPROVAL_ID` and `AI_FILTER_EVAL_RUN_ID`;
+- `AI_FILTER_EVAL_APPROVED_HOST` (including the explicit port when present);
+- `AI_FILTER_EVAL_APPROVED_DATABASE`; and
+- `AI_FILTER_EVAL_APPROVED_ROLE`.
+
+Then run exactly:
+
+```sh
+pnpm ai-filter-eval:census -- --confirm-read-only-production-census > "$APPROVED_PRIVATE_CENSUS_PATH"
+```
+
+The collector requires certificate-verified TLS (`sslmode=verify-full`),
+verifies the expected database and role, verifies both default and current
+read-only state, checks that the role lacks write privileges on the two source
+tables, and emits only fixed aggregate cells with complementary suppression.
+Record the command exit status and output digest in #8325 without attaching the
+private census. Do not rerun automatically after a timeout or partial failure;
+the access owner decides whether a replacement run is allowed.
+
+The census is deliberately marked `aggregate_shape_approximation_v1` because
+PostgreSQL and JavaScript differ on unusual Unicode trim/length/case behavior.
+It is sufficient for coarse slot planning, not admission into the dataset. The
+later bounded extractor must run each selected configuration through
+`normalizeWatchlistFiltersForRead` before fingerprinting or candidate reads;
+invalid or normalized-duplicate rows are replaced inside the same preapproved
+slot policy.
+
+## Blind agent calibration
+
+Before v1 annotation, compare `gpt-5.6-sol` and `gpt-5.6-terra` across the
+predeclared reasoning-effort settings on the same disposable set of 24-32
+human-reviewed pairs. The set is disjoint from the 200-pair corpus and is not
+reused in model benchmarking.
+
+Human labels and model/configuration identities remain hidden during each run.
+Freeze prompts and decoding/output rules first, randomize presentation order,
+run configurations in isolated contexts, and score only after outputs are
+locked. Record pair agreement with the human, accept/reject errors, ambiguity,
+schema validity, run-to-run consistency, latency, and token use. The
+calibration manifest must enumerate the tested effort values—no model default
+may stand in for a pin—and record the selected labeller and adjudicator
+configurations before the 200 pairs are opened for annotation.
+
+Calibration data is destroyed or quarantined as non-benchmark material after
+the selection record is complete. It must not inflate v1 quality results.
+
+## Annotation and adjudication
+
+All 200 pairs are independently labelled twice by agents. A label is binary
+accept/reject plus clear/ambiguous, with an optional evidence span or concise
+QA note. The second labeller cannot see the first label, its rationale, model
+identity, or run metadata. Completeness is `200 * 2 = 400` locked primary
+labels; partial double-labelling is not acceptable.
+
+Every disagreement in either decision or ambiguity state is adjudicated by a
+separate agent pass after both primary labels are locked. The adjudication
+record names the stable pair ID, both label record IDs, final decision, final
+ambiguity state, and concise rationale. Preserve rather than overwrite both
+primary labels. Agreement does not skip the later human audit.
+
+Agent-only output is **silver**, even after agent adjudication. It remains
+silver until a bounded human audit, with its size and stratified selection rule
+precommitted before agent labels are revealed, is complete and an authorized
+human records an explicit accept/revise/reject decision. The audit covers both
+cohorts and samples agreements as well as disagreements. Audit findings are
+resolved by stable ID; no silent bulk relabelling is allowed. Dataset-level
+approval does not imply that every row was human-labelled, so every row keeps
+its `agent_agreed`, `agent_adjudicated`, or `human_reviewed` provenance.
+
+Because the existing Draft harness has no real corpus, reconcile it as a hard
+schema-v2 cut rather than adding a v1 migration layer. Preserve its strict
+validation, canonical digests, private-path controls, immutable publication,
+and nonleaking errors, but replace the obsolete human-authorship model with
+explicit bundle/pair, cohort, persona, evidence, ambiguity, agent-provenance,
+silver, audit, and gold records. Reject v1 artifacts instead of converting
+them.
+
+Target-model predictions are not a field in WIP, silver, or gold artifacts.
+The AF-3 prediction loader exposes only stable pair ID, soft query, and
+classifier input; a separate scorer joins locked predictions to labels after
+the run. This prevents the target-model call path from receiving gold labels
+or annotation metadata.
+
+## Human review packet
+
+Use two small, static, private Markdown packets. Do not build a custom UI,
+database, authentication layer, or review service for this delivery.
+
+1. **Prompt sanity packet:** before labels exist, show 12 representative bundle
+   cards spanning all locales and major persona classes. Each card contains its
+   stable bundle ID, generalized hard-filter context, proposed prompt, and
+   three posting titles. The reviewer marks `keep`, `revise`, or `reject`.
+2. **Label audit packet:** after agent adjudication, show at most 32 pair cards:
+   up to 16 stratified agreements, up to eight adjudicated disagreements, and
+   up to eight ambiguous or policy-boundary cases. Backfill unused slots with
+   stratified agreements. Each card contains its stable pair ID, cohort,
+   prompt, and normalized posting payload. The first pass remains blind to
+   agent labels and configuration identities; comparison is shown only after
+   the human decision is locked.
+
+The packet cover asks for only the decisions needed at that gate. The prompt
+pass is `keep`, `revise`, or `reject` plus an optional short note. The label
+pass is `accept`, `reject`, or `unclear` plus an optional short note. Twelve
+prompt cards and at most 32 label cards are the complete planned human review
+surface; no dashboard, queue, account, or workflow UI is part of v1.
+
+If the disagreement or policy-boundary volume cannot fit this bounded packet,
+do not turn the packet into a larger interface. Fail the fleet-quality gate,
+repair the rubric or agent routing, and rerun the affected slice.
+
+The reviewer records feedback in Markdown keyed only by stable ID, for example:
+
+```markdown
+| pair_id | human_decision | ambiguity | disposition | note |
+|---|---|---|---|---|
+| aife-v1-b07-p03 | accept | clear | agree | Required evidence is explicit. |
+```
+
+For the first delivery, the orchestrator checks the returned stable IDs and
+echoes its interpretation for confirmation; no separate feedback application
+or general-purpose form engine is required. Store the packet and feedback
+beside the private dataset, not in Git or production. Preserve packet and
+feedback digests in the non-sensitive release manifest.
+
+## Deliverables
+
+Repository-safe deliverables:
+
+- this execution plan and a versioned annotation/schema contract;
+- deterministic sampler, normalizer, manifest, and small Markdown-packet
+  generator with synthetic fixtures only;
+- validators for counts, stable IDs, cohort separation, independent labels,
+  and adjudication completeness; and
+- a sanitized result report containing aggregate/cohort metrics, provenance,
+  version pins, artifact digests, audit disposition, and no private content.
+
+Private deliverables:
+
+- the approved de-identified filter snapshot and extraction log;
+- the 25 frozen feed-prompt bundles and 200 normalized pairs;
+- the disposable calibration set and locked calibration result;
+- 400 primary labels, disagreement/adjudication records, and provenance; and
+- the human review packet, feedback-by-ID file, remediation record, and signed
+  release decision.
+
+## Quality gates
+
+The delivery fails closed unless all gates pass:
+
+1. **Policy and authority:** the #8325 decision record and #8498 implementation
+   agree; privacy, licensing, model-processing, storage, and exact read-only
+   access are approved before production access.
+2. **Reproducibility:** normalizer, candidate compiler/order, window, source
+   revision, dependencies, ordered IDs, and normalized payload digests are
+   pinned. Rerunning local fixtures is deterministic.
+3. **Shape:** exactly 20 distinct filter fingerprints, 25 bundles, eight pairs
+   per bundle, 200 stable unique pair IDs, and separately identified
+   production-shaped and challenge cohorts.
+4. **Privacy:** automated and manual checks find no prohibited identifiers,
+   secrets, raw private prompts, or unapproved fields; private artifacts never
+   enter Git or the public dataset.
+5. **Calibration:** the blind 24-32-pair comparison is complete and selected
+   agent/configuration pins are frozen before corpus labelling.
+6. **Labelling:** exactly 400 independent primary labels exist; all
+   disagreements are adjudicated with original labels retained.
+7. **Human audit:** the precommitted bounded packet is complete, feedback IDs
+   validate, findings are resolved, and the human release decision is
+   explicit. Until then the dataset is silver.
+8. **Release:** the private manifest and sanitized report agree on counts and
+   digests, production-shaped and challenge results are reported separately,
+   and no calibration pair appears in the 200-pair benchmark.
+
+## Issue and PR sequence
+
+1. Merge the documentation-only plan PR. It grants no data-access authority.
+2. Reconcile #8498 with the approved #8325 synthetic-prompt, double-agent-label,
+   agent-adjudication, and human-audit workflow; record the remaining
+   production-read approvals on #8325.
+3. Open a tooling PR containing only schemas, deterministic extraction and
+   validation code, the exact normalizer/order pins, packet generation, and
+   synthetic tests. Review it without production credentials or data.
+4. After that PR passes and the named production-read approval is recorded,
+   perform the single bounded read-only extraction into approved private
+   storage and freeze the 25-bundle manifest.
+5. Run and lock blind calibration, then run 400 independent labels and
+   adjudicate every disagreement. Validate the private corpus as silver.
+6. Generate the static Markdown audit packet, collect human feedback by stable
+   ID, resolve findings, and record the release decision.
+7. Open a results PR with only the sanitized report, schema/tooling fixes, and
+   non-sensitive version/digest metadata. Do not attach the private corpus.
+8. Only after all gates close may #8326 consume the approved v1 corpus for the
+   classifier benchmark. Expansion toward 1,000 pairs is a separately approved
+   follow-up, not an automatic continuation.

--- a/docs/19-ai-filter-evaluation-data.md
+++ b/docs/19-ai-filter-evaluation-data.md
@@ -68,8 +68,9 @@ population without repeatedly exposing production rows:
 4. Materialize 15 distinct filters as 15 production-shaped bundles. Each keeps
    the first eight eligible candidates in the pinned total order.
 5. Materialize the other five distinct filters as two challenge bundles each,
-   yielding ten challenge bundles. The two prompts may differ, but their
-   candidate selection rules are predeclared and label-blind. Challenge
+   yielding ten challenge bundles. The two prompts differ, but both bundles
+   reuse the same ordered frozen eight-posting feed so the comparison changes
+   only the prompt/persona. Challenge
    heuristics may target missing evidence, close lexical matches, multilingual
    content, contradictions, and prompt-injection text; they may not inspect a
    fit label or target-model prediction.
@@ -83,22 +84,25 @@ than quietly substituting rows.
 Raw keyword text, when present, may be used only inside the approved boundary
 to reproduce the source candidate feed. Prompt authors receive the generalized
 filter shape and frozen feed, never that text. The private manifest records
-only keyword presence/count plus an approved non-reversible fingerprint if one
-is required for replay validation.
+only keyword presence/count plus per-run `hmac-sha256-v1` fingerprints of the
+canonical filter and exact compiled query. The HMAC key never enters the
+dataset or release manifest.
 
 ## Required fidelity pins
 
 The extraction manifest must make the sample replayable without silently
 following moving code or data:
 
-- repository commit OID, schema version, UTC extraction cutoff, inclusive and
-  exclusive window bounds, Typesense collection/alias target, and canonical
+- repository commit OID, schema version, UTC extraction cutoff, strict and
+  effective inclusive/exclusive window bounds, Typesense alias plus its
+  resolved versioned collection (or approved snapshot digest), and canonical
   fingerprints of all 20 de-identified filters;
 - exact normalizer file/function, source digest, dependency-lock digest,
   locale fallback order, included payload fields, Unicode/line-ending rules,
   HTML-to-text behavior, and 12,000-character text-boundary truncation rule;
-- exact candidate compiler/reader file and function, filter string, search
-  parameters, page size, and candidate-order policy; and
+- exact candidate compiler/reader file and exported function, source digest,
+  filter/query template, search parameters, page size, and candidate-order
+  policy; and
 - ordered posting IDs before and after any challenge selection, plus a digest
   of each final normalized classifier payload.
 
@@ -211,7 +215,12 @@ locked. Record pair agreement with the human, accept/reject errors, ambiguity,
 schema validity, run-to-run consistency, latency, and token use. The
 calibration manifest must enumerate the tested effort values—no model default
 may stand in for a pin—and record the selected labeller and adjudicator
-configurations before the 200 pairs are opened for annotation.
+configurations before the 200 pairs are opened for annotation. A role needs at
+least two semantically distinct candidates, identified by model, model version,
+reasoning effort, and task-prompt digest; renaming an otherwise identical setup
+does not count. Each aggregate trial records its calibration-suite digest,
+sample count, locked-output digest, blind score, spot-check notes, and observed
+failure modes.
 
 Calibration data is destroyed or quarantined as non-benchmark material after
 the selection record is complete. It must not inflate v1 quality results.
@@ -226,10 +235,11 @@ Tune each fleet role independently rather than choosing one global model:
   ambiguity agreement, repeat consistency, false-accept/false-reject balance,
   schema validity, latency, and token cost;
 - **adjudicator:** use prebuilt conflicting annotation records over the same
-  disposable pairs and score resolution against the locked human decision; and
+  disposable pairs, including at least eight seeded conflicts, and score
+  resolution against the locked human decision; and
 - **final critic:** use synthetic manifests with seeded provenance, leakage,
-  count, blindness, and cohort-reporting defects and measure defect recall plus
-  false alarms.
+  count, blindness, and cohort-reporting defects, including at least eight
+  seeded defects, and measure defect recall plus false alarms.
 
 For each role, the orchestrator spot-checks raw outputs before scores are
 unblinded, records observed failure modes, and may refine the task prompt only
@@ -286,19 +296,22 @@ annotation, while the final audit must stay blind until silver labels lock.
    separately approved calibration set. Each card contains a stable calibration
    ID, synthetic prompt, and normalized posting payload. The reviewer marks
    `accept`, `reject`, or `unclear`; model/configuration identities and outputs
-   remain hidden until all human labels lock. These examples and labels never
-   enter the final 200-pair corpus.
+   remain hidden until all human labels lock. `Unclear` is preserved but does
+   not become calibration ground truth; at least 24 cards must resolve to
+   `accept` or `reject`. These examples and labels never enter the final
+   200-pair corpus.
 2. **Prompt sanity packet:** before final labels exist, show 12 representative bundle
    cards spanning all locales and major persona classes. Each card contains its
    stable bundle ID, generalized hard-filter context, proposed prompt, and
    three posting titles. The reviewer marks `keep`, `revise`, or `reject`.
-3. **Label audit packet:** after agent adjudication, show at most 32 pair cards:
-   up to 16 stratified agreements, up to eight adjudicated disagreements, and
-   up to eight ambiguous or policy-boundary cases. Backfill unused slots with
-   stratified agreements. Each card contains its stable pair ID, cohort,
-   prompt, and normalized posting payload. The first pass remains blind to
-   agent labels and configuration identities; comparison is shown only after
-   the human decision is locked.
+3. **Label audit packet:** after agent adjudication, show 32 pair cards. Include
+   every ambiguous/policy-boundary case and every adjudicated disagreement, up
+   to eight of each; if either category exceeds eight, fail the fleet-quality
+   gate instead of hiding cases. Fill the remaining slots deterministically
+   with cohort-stratified agreements. Each card contains only its stable pair
+   ID, prompt, and normalized posting payload. The first pass hides cohort,
+   agent labels, ambiguity, adjudication, configuration, and provenance;
+   comparison is shown only after the human decision is locked.
 
 Each packet cover asks for only the decisions needed at that gate. Calibration
 and label-audit passes use `accept`, `reject`, or `unclear`; the prompt pass uses
@@ -363,7 +376,9 @@ The delivery fails closed unless all gates pass:
    secrets, raw private prompts, or unapproved fields; private artifacts never
    enter Git or the public dataset.
 5. **Calibration:** the blind 24-32-pair comparison is complete and selected
-   agent/configuration pins are frozen before corpus labelling.
+   agent/configuration pins are frozen before corpus labelling; each role was
+   compared across at least two semantically distinct configurations on one
+   locked suite, with at least 24 resolved human decisions.
 6. **Labelling:** exactly 400 independent primary labels exist; all
    disagreements are adjudicated with original labels retained.
 7. **Human audit:** the precommitted bounded packet is complete, feedback IDs

--- a/docs/19-ai-filter-evaluation-data.md
+++ b/docs/19-ai-filter-evaluation-data.md
@@ -32,7 +32,9 @@ account IDs or raw content. A posting may occur under more than one prompt, but
 each `(bundle ID, position)` is one distinct pair. Once annotation begins,
 replacement or reordering requires a new dataset version.
 
-Keep two cohorts separate in manifests, review packets, and reports:
+Keep two cohorts separate in manifests, prompt-sanity review context, and
+reports. The blind final label-audit packet intentionally hides cohort until
+the reviewer decision is locked:
 
 - **Production-shaped** bundles preserve a real structured-filter shape,
   observed candidate base rate, and the first eight eligible candidates in the
@@ -203,10 +205,12 @@ slot policy.
 
 ## Blind agent calibration
 
-Before v1 annotation, compare `gpt-5.6-sol` and `gpt-5.6-terra` across the
-predeclared reasoning-effort settings on the same disposable set of 24-32
-human-reviewed pairs. The set is disjoint from the 200-pair corpus and is not
-reused in model benchmarking.
+Before v1 annotation, compare at least two predeclared, semantically distinct
+model/reasoning configurations on the same disposable set of 24-32
+human-reviewed pairs. Start with `gpt-5.6-sol` and `gpt-5.6-terra` as candidate
+families when both are available, but keep the validator provider-neutral and
+make the locked calibration manifest the source of truth. The set is disjoint
+from the 200-pair corpus and is not reused in model benchmarking.
 
 Human labels and model/configuration identities remain hidden during each run.
 Freeze prompts and decoding/output rules first, randomize presentation order,

--- a/docs/19-ai-filter-evaluation-data.md
+++ b/docs/19-ai-filter-evaluation-data.md
@@ -253,16 +253,24 @@ classifier input; a separate scorer joins locked predictions to labels after
 the run. This prevents the target-model call path from receiving gold labels
 or annotation metadata.
 
-## Human review packet
+## Human review packets
 
-Use two small, static, private Markdown packets. Do not build a custom UI,
-database, authentication layer, or review service for this delivery.
+Use three small, static, private Markdown packets. Do not build a custom UI,
+database, authentication layer, or review service for this delivery. They are
+separate because calibration must finish before final prompt generation and
+annotation, while the final audit must stay blind until silver labels lock.
 
-1. **Prompt sanity packet:** before labels exist, show 12 representative bundle
+1. **Agent-calibration packet:** show 24-32 disposable pair cards drawn from the
+   separately approved calibration set. Each card contains a stable calibration
+   ID, synthetic prompt, and normalized posting payload. The reviewer marks
+   `accept`, `reject`, or `unclear`; model/configuration identities and outputs
+   remain hidden until all human labels lock. These examples and labels never
+   enter the final 200-pair corpus.
+2. **Prompt sanity packet:** before final labels exist, show 12 representative bundle
    cards spanning all locales and major persona classes. Each card contains its
    stable bundle ID, generalized hard-filter context, proposed prompt, and
    three posting titles. The reviewer marks `keep`, `revise`, or `reject`.
-2. **Label audit packet:** after agent adjudication, show at most 32 pair cards:
+3. **Label audit packet:** after agent adjudication, show at most 32 pair cards:
    up to 16 stratified agreements, up to eight adjudicated disagreements, and
    up to eight ambiguous or policy-boundary cases. Backfill unused slots with
    stratified agreements. Each card contains its stable pair ID, cohort,
@@ -270,11 +278,12 @@ database, authentication layer, or review service for this delivery.
    agent labels and configuration identities; comparison is shown only after
    the human decision is locked.
 
-The packet cover asks for only the decisions needed at that gate. The prompt
-pass is `keep`, `revise`, or `reject` plus an optional short note. The label
-pass is `accept`, `reject`, or `unclear` plus an optional short note. Twelve
-prompt cards and at most 32 label cards are the complete planned human review
-surface; no dashboard, queue, account, or workflow UI is part of v1.
+Each packet cover asks for only the decisions needed at that gate. Calibration
+and label-audit passes use `accept`, `reject`, or `unclear`; the prompt pass uses
+`keep`, `revise`, or `reject`; every card has only an optional short note. The
+maximum planned human surface is 32 calibration cards, 12 prompt cards, and 32
+final-audit cards: 76 bounded decisions across three checkpoints. No dashboard,
+queue, account, or workflow UI is part of v1.
 
 If the disagreement or policy-boundary volume cannot fit this bounded packet,
 do not turn the packet into a larger interface. Fail the fleet-quality gate,

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,9 @@ Status tags:
   lifecycle and breadth limits, owned-watchlist selection/public-discovery
   retirement, exact-decision caching, model-evaluation/spend gates, and the
   dynamic gated epic issue tree.
+- [19 - AI-filter Evaluation Data Delivery](19-ai-filter-evaluation-data.md)
+  `[proposal]` - approved bounded 200-pair sampling, agent labelling,
+  adjudication, private human audit, and production-access gates.
 
 ## Agent And Automation Workflows
 


### PR DESCRIPTION
Addresses #8325 without closing it.

## Outcome

Records the durable 200-pair AI-filter evaluation-data plan and adds an independently reviewed aggregate-only census for planning a diverse production sample. The human review surface is deliberately limited to three private static Markdown packets; this PR adds no UI or review service.

## Delivery shape

- 20 distinct production-derived structured filters
- 25 eight-posting feed/prompt bundles = exactly 200 pairs
- 15 production-shaped bundles / 120 pairs, reported separately from 10 challenge bundles / 80 pairs
- diverse synthetic prompt personas; reused challenge filters compare different prompts over the same frozen feed
- provider-neutral blind calibration of at least two semantically distinct model/reasoning configurations per fleet role
- two independent blind agent labels on every pair, separate adjudication, explicit silver state, then bounded human audit before gold
- private artifacts only; no corpus data, production identifiers, raw user prompts, filter/query values, or HMAC key in Git/public Hugging Face

Human feedback is exactly three static packets: 24–32 calibration cards, 12 prompt cards, and 32 blind final-audit cards—at most 76 decisions total.

## Aggregate census

The offline CLI emits one fixed aggregate row with coordinated small-cell suppression and no per-watchlist data. It requires an explicit approval/run identity, certificate-verified TLS, the exact approved host/database/SELECT-only role, read-only transaction state, source-table privilege checks, and sanitized failures. The SQL result is explicitly an approximate coarse-shape census; final extraction uses the exact application normalizer.

No production connection or data read was made while building or testing this PR.

## Review and verification

Exact head: `27484e6286d2b7c025d53a1c2f4fe77e43b71fc3`.

- census tests: 13/13
- targeted ESLint and full TypeScript: passed
- disposable PostgreSQL malformed-JSON exercise: passed
- final census reviewer and privacy critic: no P1/P2/P3
- plan/Stage A consistency critic found four real gaps; all were remediated in this plan and Draft #8498, whose corrected exact head has separate independent approval

## Remaining gates

This Draft grants no production-read authority. Before the aggregate census, #8325 must record the named DRI; privacy/licensing, access, retention/deletion, and model-processing approvals; final audit reviewer; exact expiring SELECT-only credentials and TLS endpoint; private output location/access roster; deletion date; approval ID; and unique one-shot run ID.

Before row extraction, Draft #8882 still needs a reviewed production-shaped Typesense memory/headroom benchmark, rollout/backfill, and a fresh full reconciliation receipt. No provider traffic, target-model benchmark, production runtime, deployment, or merge is authorized.
