### PR TITLE
Add guarded routine web migration workflow

### DIFF
--- a/.github/workflows/apply-web-routine-migration.yml
+++ b/.github/workflows/apply-web-routine-migration.yml
@@ -50,10 +50,14 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           GIT_REF: ${{ github.ref }}
           DISPATCH_SHA: ${{ github.sha }}
+          DISPATCH_ACTOR: ${{ github.actor }}
+          DISPATCH_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
           test "$EVENT_NAME" = workflow_dispatch
           test "$GIT_REF" = refs/heads/main
+          test "$DISPATCH_ACTOR" = viktor-shcherb
+          test "$DISPATCH_TRIGGERING_ACTOR" = viktor-shcherb
           [[ "$ROUTINE_MIGRATION_REVISION" =~ ^[0-9a-f]{40}$ ]]
           test "$DISPATCH_SHA" = "$ROUTINE_MIGRATION_REVISION"
 
@@ -92,9 +96,11 @@ jobs:
       - name: Record protected owner authorization
         env:
           AUTHORIZING_ACTOR: ${{ github.actor }}
+          AUTHORIZING_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
           test "$AUTHORIZING_ACTOR" = viktor-shcherb
+          test "$AUTHORIZING_TRIGGERING_ACTOR" = viktor-shcherb
           echo "Protected approval recorded for $ROUTINE_MIGRATION_TAG at $ROUTINE_MIGRATION_REVISION." >> "$GITHUB_STEP_SUMMARY"
 
   apply:
@@ -114,17 +120,14 @@ jobs:
           ref: ${{ inputs.revision }}
           persist-credentials: false
 
-      - name: Refuse a stale or displaced main revision before DDL
+      - name: Validate the checked-out dispatch revision before setup
         env:
-          REPOSITORY: ${{ github.repository }}
           DISPATCH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           test -n "$DATABASE_URL_UNPOOLED"
           test "$DISPATCH_SHA" = "$ROUTINE_MIGRATION_REVISION"
           test "$(git rev-parse HEAD)" = "$ROUTINE_MIGRATION_REVISION"
-          remote_main_sha="$(gh api "repos/$REPOSITORY/git/ref/heads/main" --jq .object.sha)"
-          test "$remote_main_sha" = "$ROUTINE_MIGRATION_REVISION"
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
@@ -139,6 +142,21 @@ jobs:
       - name: Revalidate the exact routine target
         working-directory: apps/web
         run: pnpm db:migrate:validate-routine
+
+      - name: Reauthorize and refuse stale main immediately before DDL
+        env:
+          REPOSITORY: ${{ github.repository }}
+          DISPATCH_SHA: ${{ github.sha }}
+          DISPATCH_ACTOR: ${{ github.actor }}
+          DISPATCH_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          test "$DISPATCH_ACTOR" = viktor-shcherb
+          test "$DISPATCH_TRIGGERING_ACTOR" = viktor-shcherb
+          test "$DISPATCH_SHA" = "$ROUTINE_MIGRATION_REVISION"
+          test "$(git rev-parse HEAD)" = "$ROUTINE_MIGRATION_REVISION"
+          remote_main_sha="$(gh api "repos/$REPOSITORY/git/ref/heads/main" --jq .object.sha)"
+          test "$remote_main_sha" = "$ROUTINE_MIGRATION_REVISION"
 
       - name: Apply exactly one reviewed migration under the ledger lock
         working-directory: apps/web

--- a/.github/workflows/apply-web-routine-migration.yml
+++ b/.github/workflows/apply-web-routine-migration.yml
@@ -1,0 +1,160 @@
+name: Apply Routine Web Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: "Current main commit (lowercase 40-hex)"
+        required: true
+        type: string
+      migration_tag:
+        description: "Reviewed allowlisted journal-head tag"
+        required: true
+        type: string
+      migration_created_at:
+        description: "Exact journal timestamp"
+        required: true
+        type: string
+      migration_hash:
+        description: "Exact lowercase SHA-256 of the SQL migration"
+        required: true
+        type: string
+      confirmation:
+        description: "APPLY-ROUTINE-WEB-MIGRATION:<tag>:<timestamp>:<hash>"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  MIGRATION_REQUIRE_UNPOOLED: "true"
+  ROUTINE_MIGRATION_REVISION: ${{ inputs.revision }}
+  ROUTINE_MIGRATION_TAG: ${{ inputs.migration_tag }}
+  ROUTINE_MIGRATION_CREATED_AT: ${{ inputs.migration_created_at }}
+  ROUTINE_MIGRATION_HASH: ${{ inputs.migration_hash }}
+  ROUTINE_MIGRATION_CONFIRMATION: ${{ inputs.confirmation }}
+
+concurrency:
+  group: web-database-migrations-production
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Require a main dispatch at the supplied immutable revision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_NAME" = workflow_dispatch
+          test "$GIT_REF" = refs/heads/main
+          [[ "$ROUTINE_MIGRATION_REVISION" =~ ^[0-9a-f]{40}$ ]]
+          test "$DISPATCH_SHA" = "$ROUTINE_MIGRATION_REVISION"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.revision }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install locked dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate the reviewed local migration identity
+        working-directory: apps/web
+        run: pnpm db:migrate:validate-routine
+
+      - name: Test routine migration safety contracts
+        working-directory: apps/web
+        run: >-
+          pnpm exec vitest run
+          src/db/__tests__/routine-migration.test.ts
+          src/db/__tests__/production-migration-safety.test.ts
+
+  authorize:
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production-migrations
+    timeout-minutes: 5
+    steps:
+      - name: Record protected owner authorization
+        env:
+          AUTHORIZING_ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          test "$AUTHORIZING_ACTOR" = viktor-shcherb
+          echo "Protected approval recorded for $ROUTINE_MIGRATION_TAG at $ROUTINE_MIGRATION_REVISION." >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    needs: [validate, authorize]
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 20
+    concurrency:
+      group: crawler-production-sync
+      cancel-in-progress: false
+    env:
+      DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.revision }}
+          persist-credentials: false
+
+      - name: Refuse a stale or displaced main revision before DDL
+        env:
+          REPOSITORY: ${{ github.repository }}
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test -n "$DATABASE_URL_UNPOOLED"
+          test "$DISPATCH_SHA" = "$ROUTINE_MIGRATION_REVISION"
+          test "$(git rev-parse HEAD)" = "$ROUTINE_MIGRATION_REVISION"
+          remote_main_sha="$(gh api "repos/$REPOSITORY/git/ref/heads/main" --jq .object.sha)"
+          test "$remote_main_sha" = "$ROUTINE_MIGRATION_REVISION"
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install locked dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Revalidate the exact routine target
+        working-directory: apps/web
+        run: pnpm db:migrate:validate-routine
+
+      - name: Apply exactly one reviewed migration under the ledger lock
+        working-directory: apps/web
+        run: timeout --signal=TERM --kill-after=15s 12m pnpm db:migrate
+
+      - name: Verify the exact checked-out migration head
+        working-directory: apps/web
+        run: pnpm db:migrate:verify-head
+
+      - name: Publish non-sensitive migration evidence
+        if: always()
+        run: |
+          {
+            echo "### Routine web migration"
+            echo "- Revision: \`$ROUTINE_MIGRATION_REVISION\`"
+            echo "- Tag: \`$ROUTINE_MIGRATION_TAG\`"
+            echo "- Timestamp: \`$ROUTINE_MIGRATION_CREATED_AT\`"
+            echo "- Hash: \`$ROUTINE_MIGRATION_HASH\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/web/drizzle/routine-migrations.json
+++ b/apps/web/drizzle/routine-migrations.json
@@ -1,0 +1,9 @@
+{
+  "migrations": [
+    {
+      "tag": "0090_migrate_internship_watchlist_filters",
+      "createdAt": 1789127975000,
+      "hash": "68ed375df80d833891dbfa233cd004e45a7a5afe88bb1d24943e70934ca63850"
+    }
+  ]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "compile": "lingui compile",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/db/migrate.ts",
+    "db:migrate:validate-routine": "tsx scripts/validate-routine-migration.ts",
     "db:migrate:verify-head": "tsx scripts/verify-production-migration-head.ts",
     "db:migrate:apply-account-issuer": "tsx scripts/apply-better-auth-account-issuer.ts",
     "db:migrate:verify-account-issuer": "tsx scripts/verify-better-auth-account-issuer.ts",

--- a/apps/web/scripts/validate-routine-migration.ts
+++ b/apps/web/scripts/validate-routine-migration.ts
@@ -1,0 +1,36 @@
+import { resolve } from "node:path";
+
+import dotenv from "dotenv";
+
+import {
+  expectedRoutineMigrationConfirmation,
+  loadRoutineMigrationPlan,
+} from "../src/db/routine-migration";
+import { logExternalError } from "../src/lib/safe-external-error";
+
+dotenv.config({ path: ".env.local", quiet: true });
+
+function main(): void {
+  const plan = loadRoutineMigrationPlan(resolve(process.cwd(), "drizzle"));
+  if (!plan) throw new Error("ROUTINE_MIGRATION_TAG must be set");
+
+  process.stdout.write(`${JSON.stringify({
+    event: "routine_migration_target_validated",
+    revision: plan.revision,
+    migration: plan.target,
+    prerequisite: plan.prerequisite,
+    localMigrationCount: plan.localMigrationCount,
+    confirmation: expectedRoutineMigrationConfirmation(plan.target),
+  })}\n`);
+}
+
+try {
+  main();
+} catch (error: unknown) {
+  logExternalError(
+    "error",
+    { service: "database", operation: "validate_routine_migration" },
+    error,
+  );
+  process.exitCode = 1;
+}

--- a/apps/web/src/db/__tests__/production-migration-safety.test.ts
+++ b/apps/web/src/db/__tests__/production-migration-safety.test.ts
@@ -171,11 +171,30 @@ describe("production migration safety", () => {
     expect(workflow).toContain("ROUTINE_MIGRATION_HASH:");
     expect(workflow).toContain("ROUTINE_MIGRATION_CONFIRMATION:");
     expect(workflow).toContain("git/ref/heads/main");
+    expect(workflow.match(/github\.triggering_actor/g)).toHaveLength(3);
+    expect(workflow).toContain(
+      'test "$AUTHORIZING_TRIGGERING_ACTOR" = viktor-shcherb',
+    );
+    expect(workflow).toContain(
+      'test "$DISPATCH_TRIGGERING_ACTOR" = viktor-shcherb',
+    );
     expect(workflow).toContain('test "$remote_main_sha" = "$ROUTINE_MIGRATION_REVISION"');
     expect(workflow).toContain("pnpm db:migrate:validate-routine");
     expect(workflow).toContain("12m pnpm db:migrate");
     expect(workflow).toContain("pnpm db:migrate:verify-head");
     expect(workflow).not.toContain("RETIREMENT_ATTESTATION_MODE");
+
+    const finalMainCheck = workflow.lastIndexOf(
+      'test "$remote_main_sha" = "$ROUTINE_MIGRATION_REVISION"',
+    );
+    const workflowMigration = workflow.indexOf(
+      "timeout --signal=TERM --kill-after=15s 12m pnpm db:migrate",
+    );
+    expect(finalMainCheck).toBeGreaterThan(-1);
+    expect(finalMainCheck).toBeLessThan(workflowMigration);
+    expect(workflow.slice(finalMainCheck, workflowMigration)).not.toContain(
+      "uses:",
+    );
 
     const lock = runner.indexOf("pg_try_advisory_lock");
     const preflight = runner.indexOf('"preflight"');

--- a/apps/web/src/db/__tests__/production-migration-safety.test.ts
+++ b/apps/web/src/db/__tests__/production-migration-safety.test.ts
@@ -155,4 +155,37 @@ describe("production migration safety", () => {
     expect(verifier).toContain('new URL(databaseUrl).port === "6543"');
     expect(verifier).toContain("assertMigrationHead(expected, observed)");
   });
+
+  it("applies routine migrations through a separately protected exact-target path", () => {
+    const workflow = readRepo(
+      ".github/workflows/apply-web-routine-migration.yml",
+    );
+    const runner = readWeb("src/db/migrate.ts");
+
+    expect(workflow).toContain("environment: production-migrations");
+    expect(workflow).toContain("environment: production");
+    expect(workflow).toContain("MIGRATION_REQUIRE_UNPOOLED: \"true\"");
+    expect(workflow).toContain("ROUTINE_MIGRATION_REVISION:");
+    expect(workflow).toContain("ROUTINE_MIGRATION_TAG:");
+    expect(workflow).toContain("ROUTINE_MIGRATION_CREATED_AT:");
+    expect(workflow).toContain("ROUTINE_MIGRATION_HASH:");
+    expect(workflow).toContain("ROUTINE_MIGRATION_CONFIRMATION:");
+    expect(workflow).toContain("git/ref/heads/main");
+    expect(workflow).toContain('test "$remote_main_sha" = "$ROUTINE_MIGRATION_REVISION"');
+    expect(workflow).toContain("pnpm db:migrate:validate-routine");
+    expect(workflow).toContain("12m pnpm db:migrate");
+    expect(workflow).toContain("pnpm db:migrate:verify-head");
+    expect(workflow).not.toContain("RETIREMENT_ATTESTATION_MODE");
+
+    const lock = runner.indexOf("pg_try_advisory_lock");
+    const preflight = runner.indexOf('"preflight"');
+    const migration = runner.indexOf("await migrate(db");
+    const postflight = runner.indexOf('"postflight"');
+    const unlock = runner.indexOf("pg_advisory_unlock");
+    expect(lock).toBeGreaterThan(-1);
+    expect(lock).toBeLessThan(preflight);
+    expect(preflight).toBeLessThan(migration);
+    expect(migration).toBeLessThan(postflight);
+    expect(postflight).toBeLessThan(unlock);
+  });
 });

--- a/apps/web/src/db/__tests__/routine-migration.test.ts
+++ b/apps/web/src/db/__tests__/routine-migration.test.ts
@@ -1,0 +1,92 @@
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assertRoutineMigrationLedger,
+  expectedRoutineMigrationConfirmation,
+  loadRoutineMigrationPlan,
+} from "../routine-migration";
+
+const migrationFolder = resolve(process.cwd(), "drizzle");
+const target = {
+  tag: "0090_migrate_internship_watchlist_filters",
+  createdAt: 1_789_127_975_000,
+  hash: "68ed375df80d833891dbfa233cd004e45a7a5afe88bb1d24943e70934ca63850",
+};
+const environment = {
+  MIGRATION_REQUIRE_UNPOOLED: "true",
+  ROUTINE_MIGRATION_REVISION: "1".repeat(40),
+  ROUTINE_MIGRATION_TAG: target.tag,
+  ROUTINE_MIGRATION_CREATED_AT: String(target.createdAt),
+  ROUTINE_MIGRATION_HASH: target.hash,
+  ROUTINE_MIGRATION_CONFIRMATION: expectedRoutineMigrationConfirmation(target),
+};
+
+describe("routine migration guard", () => {
+  it("binds an allowlisted target to the exact checked-out journal head", () => {
+    const plan = loadRoutineMigrationPlan(migrationFolder, environment);
+
+    expect(plan?.target).toEqual(target);
+    expect(plan?.localMigrationCount).toBe(79);
+    expect(plan?.prerequisite.tag).toBe("0089_watchlist_unlisted_sharing");
+  });
+
+  it.each([
+    ["hash", { ROUTINE_MIGRATION_HASH: "0".repeat(64) }],
+    ["timestamp", { ROUTINE_MIGRATION_CREATED_AT: "1789127975001" }],
+    ["confirmation", { ROUTINE_MIGRATION_CONFIRMATION: "APPLY" }],
+    ["revision", { ROUTINE_MIGRATION_REVISION: "deadbeef" }],
+  ])("rejects a mismatched %s", (_field, override) => {
+    expect(() =>
+      loadRoutineMigrationPlan(migrationFolder, { ...environment, ...override }),
+    ).toThrow();
+  });
+
+  it("fails closed when routine migration inputs are partial", () => {
+    expect(() =>
+      loadRoutineMigrationPlan(migrationFolder, {
+        MIGRATION_REQUIRE_UNPOOLED: "true",
+        ROUTINE_MIGRATION_REVISION: "1".repeat(40),
+      }),
+    ).toThrow(/ROUTINE_MIGRATION_TAG is required/);
+  });
+
+  it("requires the live ledger to be the exact expected transition", () => {
+    const plan = loadRoutineMigrationPlan(migrationFolder, environment)!;
+    const before = {
+      latest: plan.prerequisite,
+      prerequisiteExactRows: 1,
+      prerequisiteTimestampRows: 1,
+      prerequisiteHashRows: 1,
+      targetExactRows: 0,
+      targetTimestampRows: 0,
+      targetHashRows: 0,
+      rowsAfterPrerequisite: 0,
+      rowsAfterTarget: 0,
+    };
+    const after = {
+      ...before,
+      latest: plan.target,
+      targetExactRows: 1,
+      targetTimestampRows: 1,
+      targetHashRows: 1,
+      rowsAfterPrerequisite: 1,
+    };
+
+    expect(() => assertRoutineMigrationLedger(plan, "preflight", before)).not.toThrow();
+    expect(() => assertRoutineMigrationLedger(plan, "postflight", after)).not.toThrow();
+    expect(() =>
+      assertRoutineMigrationLedger(plan, "preflight", {
+        ...before,
+        rowsAfterPrerequisite: 1,
+      }),
+    ).toThrow(/unexpected later ledger rows/);
+    expect(() =>
+      assertRoutineMigrationLedger(plan, "postflight", {
+        ...after,
+        targetTimestampRows: 2,
+      }),
+    ).toThrow(/target identity has unexpected rows/);
+  });
+});

--- a/apps/web/src/db/migrate.ts
+++ b/apps/web/src/db/migrate.ts
@@ -1,10 +1,16 @@
 import { createHash } from "node:crypto";
+import { resolve } from "node:path";
 import dotenv from "dotenv";
 dotenv.config({ path: ".env.local", quiet: true });
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { logExternalError } from "@/lib/safe-external-error";
+import {
+  assertRoutineMigrationLedger,
+  loadRoutineMigrationPlan,
+  type RoutineMigrationLedgerSnapshot,
+} from "@/db/routine-migration";
 
 const unpooledUrl = process.env.DATABASE_URL_UNPOOLED;
 const url = unpooledUrl ?? process.env.DATABASE_URL;
@@ -37,6 +43,9 @@ const migrationSql = postgres(url, {
   connect_timeout: 15,
   connection: { application_name: "jobseek-web-migrations" },
 });
+const routineMigrationPlan = loadRoutineMigrationPlan(
+  resolve(process.cwd(), "drizzle"),
+);
 
 type RetirementAttestationMode = "production-drop" | "restore-drill";
 
@@ -150,6 +159,52 @@ async function prepareRetirementAttestation(): Promise<void> {
   `;
 }
 
+async function readRoutineMigrationLedger(): Promise<RoutineMigrationLedgerSnapshot> {
+  if (!routineMigrationPlan) throw new Error("Routine migration plan is missing");
+  const { prerequisite, target } = routineMigrationPlan;
+  const [snapshot] = await migrationSql<RoutineMigrationLedgerSnapshot[]>`
+    SELECT
+      (
+        SELECT json_build_object(
+          'createdAt', created_at::text,
+          'hash', hash
+        )
+        FROM drizzle.__drizzle_migrations
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+      ) AS latest,
+      count(*) FILTER (
+        WHERE created_at = ${prerequisite.createdAt}
+          AND hash = ${prerequisite.hash}
+      )::integer AS "prerequisiteExactRows",
+      count(*) FILTER (
+        WHERE created_at = ${prerequisite.createdAt}
+      )::integer AS "prerequisiteTimestampRows",
+      count(*) FILTER (
+        WHERE hash = ${prerequisite.hash}
+      )::integer AS "prerequisiteHashRows",
+      count(*) FILTER (
+        WHERE created_at = ${target.createdAt}
+          AND hash = ${target.hash}
+      )::integer AS "targetExactRows",
+      count(*) FILTER (
+        WHERE created_at = ${target.createdAt}
+      )::integer AS "targetTimestampRows",
+      count(*) FILTER (
+        WHERE hash = ${target.hash}
+      )::integer AS "targetHashRows",
+      count(*) FILTER (
+        WHERE created_at > ${prerequisite.createdAt}
+      )::integer AS "rowsAfterPrerequisite",
+      count(*) FILTER (
+        WHERE created_at > ${target.createdAt}
+      )::integer AS "rowsAfterTarget"
+    FROM drizzle.__drizzle_migrations
+  `;
+  if (!snapshot) throw new Error("Could not read the Drizzle migration ledger");
+  return snapshot;
+}
+
 async function main() {
   let lockConnection:
     | Awaited<ReturnType<typeof lockSql.reserve>>
@@ -178,10 +233,30 @@ async function main() {
     await migrationSql`SET statement_timeout = '10min'`;
     await migrationSql`SET idle_in_transaction_session_timeout = '2min'`;
     await prepareRetirementAttestation();
+    if (routineMigrationPlan) {
+      assertRoutineMigrationLedger(
+        routineMigrationPlan,
+        "preflight",
+        await readRoutineMigrationLedger(),
+      );
+      console.log(
+        `Routine migration preflight verified ${routineMigrationPlan.target.tag} at ${routineMigrationPlan.revision}.`,
+      );
+    }
 
     const db = drizzle(migrationSql);
     console.log("Running migrations with the web schema advisory lock...");
     await migrate(db, { migrationsFolder: "./drizzle" });
+    if (routineMigrationPlan) {
+      assertRoutineMigrationLedger(
+        routineMigrationPlan,
+        "postflight",
+        await readRoutineMigrationLedger(),
+      );
+      console.log(
+        `Routine migration postflight verified ${routineMigrationPlan.target.tag}.`,
+      );
+    }
     console.log("Migrations complete.");
   } finally {
     try {

--- a/apps/web/src/db/routine-migration.ts
+++ b/apps/web/src/db/routine-migration.ts
@@ -1,0 +1,217 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { readMigrationFiles, type MigrationMeta } from "drizzle-orm/migrator";
+
+export type RoutineMigrationIdentity = {
+  tag: string;
+  createdAt: number;
+  hash: string;
+};
+
+export type RoutineMigrationLedgerRow = {
+  createdAt: string | number;
+  hash: string;
+};
+
+export type RoutineMigrationLedgerSnapshot = {
+  latest: RoutineMigrationLedgerRow | null;
+  prerequisiteExactRows: number;
+  prerequisiteTimestampRows: number;
+  prerequisiteHashRows: number;
+  targetExactRows: number;
+  targetTimestampRows: number;
+  targetHashRows: number;
+  rowsAfterPrerequisite: number;
+  rowsAfterTarget: number;
+};
+
+export type RoutineMigrationPlan = {
+  revision: string;
+  prerequisite: RoutineMigrationIdentity;
+  target: RoutineMigrationIdentity;
+  localMigrationCount: number;
+};
+
+type Journal = {
+  entries: Array<{ idx: number; tag: string; when: number }>;
+};
+
+type Registry = {
+  migrations: RoutineMigrationIdentity[];
+};
+
+type RoutineMigrationEnvironment = Record<string, string | undefined>;
+
+const SHA_40 = /^[0-9a-f]{40}$/;
+const SHA_256 = /^[0-9a-f]{64}$/;
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function requiredEnvironment(
+  environment: RoutineMigrationEnvironment,
+  name: string,
+): string {
+  const value = environment[name];
+  invariant(value, `${name} is required for a routine migration`);
+  return value;
+}
+
+function parseCreatedAt(raw: string): number {
+  invariant(/^\d+$/.test(raw), "ROUTINE_MIGRATION_CREATED_AT must be numeric");
+  const value = Number(raw);
+  invariant(
+    Number.isSafeInteger(value) && value > 0,
+    "ROUTINE_MIGRATION_CREATED_AT must be a positive safe integer",
+  );
+  return value;
+}
+
+function identitiesFromJournal(
+  journal: Journal,
+  migrations: MigrationMeta[],
+): RoutineMigrationIdentity[] {
+  invariant(
+    journal.entries.length === migrations.length,
+    "Drizzle journal and SQL migration counts differ",
+  );
+
+  return journal.entries.map((entry, index) => {
+    const migration = migrations[index];
+    invariant(entry.idx === index, `Drizzle journal index ${entry.idx} is out of order`);
+    invariant(migration, `SQL migration ${entry.tag} is missing`);
+    invariant(
+      migration.folderMillis === entry.when,
+      `Migration timestamp does not match journal entry ${entry.tag}`,
+    );
+    invariant(SHA_256.test(migration.hash), `Migration hash is invalid for ${entry.tag}`);
+    return { tag: entry.tag, createdAt: entry.when, hash: migration.hash };
+  });
+}
+
+export function expectedRoutineMigrationConfirmation(
+  target: RoutineMigrationIdentity,
+): string {
+  return `APPLY-ROUTINE-WEB-MIGRATION:${target.tag}:${target.createdAt}:${target.hash}`;
+}
+
+export function loadRoutineMigrationPlan(
+  migrationFolder: string,
+  environment: RoutineMigrationEnvironment = process.env,
+): RoutineMigrationPlan | null {
+  const routineEnvironmentNames = [
+    "ROUTINE_MIGRATION_REVISION",
+    "ROUTINE_MIGRATION_TAG",
+    "ROUTINE_MIGRATION_CREATED_AT",
+    "ROUTINE_MIGRATION_HASH",
+    "ROUTINE_MIGRATION_CONFIRMATION",
+  ] as const;
+  if (!routineEnvironmentNames.some((name) => environment[name])) return null;
+  const targetTag = requiredEnvironment(environment, "ROUTINE_MIGRATION_TAG");
+
+  invariant(
+    environment.MIGRATION_REQUIRE_UNPOOLED === "true",
+    "Routine migrations require MIGRATION_REQUIRE_UNPOOLED=true",
+  );
+  invariant(
+    !environment.RETIREMENT_ATTESTATION_MODE,
+    "Routine and retirement migration modes are mutually exclusive",
+  );
+
+  const revision = requiredEnvironment(environment, "ROUTINE_MIGRATION_REVISION");
+  const createdAt = parseCreatedAt(
+    requiredEnvironment(environment, "ROUTINE_MIGRATION_CREATED_AT"),
+  );
+  const hash = requiredEnvironment(environment, "ROUTINE_MIGRATION_HASH");
+  const confirmation = requiredEnvironment(
+    environment,
+    "ROUTINE_MIGRATION_CONFIRMATION",
+  );
+  invariant(SHA_40.test(revision), "ROUTINE_MIGRATION_REVISION must be lowercase 40-hex");
+  invariant(SHA_256.test(hash), "ROUTINE_MIGRATION_HASH must be lowercase SHA-256");
+
+  const journal = JSON.parse(
+    readFileSync(resolve(migrationFolder, "meta/_journal.json"), "utf8"),
+  ) as Journal;
+  const registry = JSON.parse(
+    readFileSync(resolve(migrationFolder, "routine-migrations.json"), "utf8"),
+  ) as Registry;
+  const migrations = readMigrationFiles({ migrationsFolder: migrationFolder });
+  const identities = identitiesFromJournal(journal, migrations);
+  const target = { tag: targetTag, createdAt, hash };
+
+  invariant(
+    new Set(registry.migrations.map((entry) => entry.tag)).size ===
+      registry.migrations.length,
+    "Routine migration registry contains duplicate tags",
+  );
+  invariant(
+    registry.migrations.some(
+      (entry) =>
+        entry.tag === target.tag &&
+        entry.createdAt === target.createdAt &&
+        entry.hash === target.hash,
+    ),
+    "Requested migration identity is not in the reviewed routine registry",
+  );
+  invariant(
+    target.tag !== "0086_drop_supabase_job_posting",
+    "The destructive 0086 retirement requires its dedicated workflow",
+  );
+
+  const localTarget = identities.at(-1);
+  const prerequisite = identities.at(-2);
+  invariant(localTarget, "No local Drizzle migrations were found");
+  invariant(prerequisite, "A routine migration requires a local prerequisite");
+  invariant(
+    localTarget.tag === target.tag &&
+      localTarget.createdAt === target.createdAt &&
+      localTarget.hash === target.hash,
+    "Requested routine migration must be the exact checked-out journal head",
+  );
+  invariant(
+    confirmation === expectedRoutineMigrationConfirmation(target),
+    "ROUTINE_MIGRATION_CONFIRMATION does not bind the exact target identity",
+  );
+
+  return {
+    revision,
+    prerequisite,
+    target,
+    localMigrationCount: identities.length,
+  };
+}
+
+export function assertRoutineMigrationLedger(
+  plan: RoutineMigrationPlan,
+  phase: "preflight" | "postflight",
+  snapshot: RoutineMigrationLedgerSnapshot,
+): void {
+  const expectedLatest = phase === "preflight" ? plan.prerequisite : plan.target;
+  invariant(
+    snapshot.latest &&
+      Number(snapshot.latest.createdAt) === expectedLatest.createdAt &&
+      snapshot.latest.hash === expectedLatest.hash,
+    `Routine migration ${phase} expected latest ${expectedLatest.createdAt}/${expectedLatest.hash.slice(0, 12)}; found ${snapshot.latest?.createdAt ?? "none"}/${snapshot.latest?.hash.slice(0, 12) ?? "none"}`,
+  );
+  invariant(
+    snapshot.prerequisiteExactRows === 1 &&
+      snapshot.prerequisiteTimestampRows === 1 &&
+      snapshot.prerequisiteHashRows === 1,
+    `Routine migration ${phase} prerequisite identity is not unique: ${JSON.stringify(snapshot)}`,
+  );
+  const expectedTargetRows = phase === "preflight" ? 0 : 1;
+  invariant(
+    snapshot.targetExactRows === expectedTargetRows &&
+      snapshot.targetTimestampRows === expectedTargetRows &&
+      snapshot.targetHashRows === expectedTargetRows,
+    `Routine migration ${phase} target identity has unexpected rows: ${JSON.stringify(snapshot)}`,
+  );
+  invariant(
+    snapshot.rowsAfterPrerequisite === expectedTargetRows &&
+      snapshot.rowsAfterTarget === 0,
+    `Routine migration ${phase} found unexpected later ledger rows: ${JSON.stringify(snapshot)}`,
+  );
+}


### PR DESCRIPTION
Closes #8909

## Summary
- add a separate reviewer-gated workflow for routine web migrations, leaving the destructive 0086 workflow unchanged
- bind every dispatch to the current main revision plus the exact allowlisted migration tag, timestamp, hash, and confirmation
- validate the live 0089 to 0090 ledger transition under the existing advisory lock before and after Drizzle runs
- reject stale revisions, pooler URLs, partial inputs, unexpected later migrations, and duplicate or conflicting target identities

## Verification
- 131 web database tests passed
- TypeScript no-emit check passed
- ESLint passed
- actionlint passed
- zizmor reported no findings