### PR TITLE
Fix Better Auth migration drift semantics

### DIFF
--- a/apps/web/scripts/verify-better-auth-account-issuer.ts
+++ b/apps/web/scripts/verify-better-auth-account-issuer.ts
@@ -3,28 +3,22 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import dotenv from "dotenv";
+import { readMigrationFiles } from "drizzle-orm/migrator";
 import postgres from "postgres";
 
+import {
+  isExactAccountIssuerPostLedger,
+  isExactAccountIssuerPreLedger,
+  type AccountIssuerLedgerEvidence as LedgerEvidence,
+  type AccountIssuerMigrationIdentity,
+  type AccountIssuerMigrationRowsEvidence as MigrationRowsEvidence,
+  type AccountIssuerPostTargetRow,
+} from "../src/db/better-auth-account-issuer-ledger";
 import { logExternalError } from "../src/lib/safe-external-error";
 
 dotenv.config({ path: ".env.local", quiet: true });
 
 type Mode = "preflight" | "postflight" | "drift";
-
-type LedgerEvidence = {
-  rowCount: number;
-  latestCreatedAt: string | null;
-  latestHash: string | null;
-};
-
-type MigrationRowsEvidence = {
-  prerequisiteExact: number;
-  prerequisiteTimestamp: number;
-  prerequisiteHash: number;
-  targetExact: number;
-  targetTimestamp: number;
-  targetHash: number;
-};
 
 type AccountEvidence = {
   total: number;
@@ -46,6 +40,8 @@ const outputPath = cliArgs[1];
 
 const prerequisiteCreatedAt = 1_785_760_800_000;
 const targetCreatedAt = 1_787_560_116_000;
+const prerequisiteTag = "0086_drop_supabase_job_posting";
+const targetTag = "0087_better_auth_account_issuer";
 const expectedFunctionSource = `
 DECLARE
   expected_issuer text;
@@ -83,6 +79,43 @@ function migrationHash(filename: string): string {
   return createHash("sha256")
     .update(readFileSync(resolve(process.cwd(), "drizzle", filename)))
     .digest("hex");
+}
+
+function loadLocalPostTargetMigrations(): AccountIssuerMigrationIdentity[] {
+  const migrationFolder = resolve(process.cwd(), "drizzle");
+  const journal = JSON.parse(
+    readFileSync(resolve(migrationFolder, "meta/_journal.json"), "utf8"),
+  ) as { entries: Array<{ idx: number; tag: string; when: number }> };
+  const migrations = readMigrationFiles({ migrationsFolder: migrationFolder });
+  invariant(
+    journal.entries.length === migrations.length,
+    "Drizzle journal and SQL migration counts differ",
+  );
+  const targetIndex = journal.entries.findIndex(
+    (entry) => entry.tag === targetTag,
+  );
+  invariant(targetIndex >= 0, `Drizzle journal does not contain ${targetTag}`);
+
+  return journal.entries.slice(targetIndex).map((entry, offset) => {
+    const index = targetIndex + offset;
+    const migration = migrations[index];
+    invariant(
+      entry.idx === index,
+      `Drizzle journal index is invalid for ${entry.tag}`,
+    );
+    invariant(migration, `SQL migration is missing for ${entry.tag}`);
+    invariant(
+      migration.folderMillis === entry.when,
+      `Migration timestamp differs for ${entry.tag}`,
+    );
+    if (offset > 0) {
+      invariant(
+        entry.when > journal.entries[index - 1]!.when,
+        `Post-0087 migration timestamps are not increasing at ${entry.tag}`,
+      );
+    }
+    return { tag: entry.tag, createdAt: entry.when, hash: migration.hash };
+  });
 }
 
 function normalizeFunctionSource(source: string): string {
@@ -128,6 +161,18 @@ async function main(): Promise<void> {
 
   const prerequisiteHash = migrationHash("0086_drop_supabase_job_posting.sql");
   const targetHash = migrationHash("0087_better_auth_account_issuer.sql");
+  const prerequisite = {
+    tag: prerequisiteTag,
+    createdAt: prerequisiteCreatedAt,
+    hash: prerequisiteHash,
+  };
+  const target = { tag: targetTag, createdAt: targetCreatedAt, hash: targetHash };
+  const ledgerTransition = {
+    prerequisite,
+    target,
+    expectedPreflightRowCount: 76,
+    localPostTargetMigrations: loadLocalPostTargetMigrations(),
+  };
   const sql = postgres(databaseUrl, {
     max: 1,
     prepare: false,
@@ -175,6 +220,12 @@ async function main(): Promise<void> {
             WHERE hash = ${targetHash}
           )::integer AS "targetHash"
         FROM drizzle.__drizzle_migrations
+      `;
+      const postTargetRows = await tx<AccountIssuerPostTargetRow[]>`
+        SELECT created_at::text AS "createdAt", hash
+        FROM drizzle.__drizzle_migrations
+        WHERE created_at >= ${targetCreatedAt}
+        ORDER BY created_at, id
       `;
       const [accountRelation] = await tx<{ present: boolean }[]>`
         SELECT (to_regclass('public.account') IS NOT NULL) AS present
@@ -436,27 +487,16 @@ async function main(): Promise<void> {
           accounts.providerIssuerMismatches === 0 &&
           accounts.duplicateIssuerAccountIdentities === 0,
       );
-      const exactPreLedger = Boolean(
-        ledger?.rowCount === 76 &&
-          Number(ledger.latestCreatedAt) === prerequisiteCreatedAt &&
-          ledger.latestHash === prerequisiteHash &&
-          migrationRows?.prerequisiteExact === 1 &&
-          migrationRows.prerequisiteTimestamp === 1 &&
-          migrationRows.prerequisiteHash === 1 &&
-          migrationRows.targetExact === 0 &&
-          migrationRows.targetTimestamp === 0 &&
-          migrationRows.targetHash === 0,
+      const exactPreLedger = isExactAccountIssuerPreLedger(
+        ledger,
+        migrationRows,
+        ledgerTransition,
       );
-      const exactPostLedger = Boolean(
-        ledger?.rowCount === 77 &&
-          Number(ledger.latestCreatedAt) === targetCreatedAt &&
-          ledger.latestHash === targetHash &&
-          migrationRows?.prerequisiteExact === 1 &&
-          migrationRows.prerequisiteTimestamp === 1 &&
-          migrationRows.prerequisiteHash === 1 &&
-          migrationRows.targetExact === 1 &&
-          migrationRows.targetTimestamp === 1 &&
-          migrationRows.targetHash === 1,
+      const exactPostLedger = isExactAccountIssuerPostLedger(
+        ledger,
+        migrationRows,
+        postTargetRows,
+        ledgerTransition,
       );
       const exactPreState = Boolean(
         accountRelation?.present &&
@@ -483,18 +523,19 @@ async function main(): Promise<void> {
         status: "checking",
         migrations: {
           prerequisite: {
-            tag: "0086_drop_supabase_job_posting",
+            tag: prerequisiteTag,
             createdAt: prerequisiteCreatedAt,
             hash: prerequisiteHash,
           },
           target: {
-            tag: "0087_better_auth_account_issuer",
+            tag: targetTag,
             createdAt: targetCreatedAt,
             hash: targetHash,
           },
         },
         ledger,
         migrationRows,
+        postTargetRows,
         accountRelation: { present: accountRelation?.present ?? false },
         issuerColumn: {
           present: issuerColumns.length === 1,

--- a/apps/web/src/db/__tests__/better-auth-1-7-migration.test.ts
+++ b/apps/web/src/db/__tests__/better-auth-1-7-migration.test.ts
@@ -99,6 +99,8 @@ describe("0087 Better Auth account issuer migration", () => {
     expect(verifier).toContain("jobseek_better_auth_account_issuer_compat");
     expect(verifier).toContain("prospective");
     expect(verifier).toContain("exactPreState || exactPostState");
+    expect(verifier).toContain("isExactAccountIssuerPostLedger");
+    expect(verifier).toContain("postTargetRows");
     expect(verifier).toContain('status: "failed"');
   });
 

--- a/apps/web/src/db/__tests__/better-auth-account-issuer-ledger.test.ts
+++ b/apps/web/src/db/__tests__/better-auth-account-issuer-ledger.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isExactAccountIssuerPostLedger,
+  isExactAccountIssuerPreLedger,
+  type AccountIssuerMigrationRowsEvidence,
+} from "../better-auth-account-issuer-ledger";
+
+const prerequisite = {
+  tag: "0086_drop_supabase_job_posting",
+  createdAt: 1_785_760_800_000,
+  hash: "6".repeat(64),
+};
+const target = {
+  tag: "0087_better_auth_account_issuer",
+  createdAt: 1_787_560_116_000,
+  hash: "7".repeat(64),
+};
+const later = [
+  {
+    tag: "0088_notification_policy_foundation",
+    createdAt: 1_788_199_156_000,
+    hash: "8".repeat(64),
+  },
+  {
+    tag: "0089_watchlist_unlisted_sharing",
+    createdAt: 1_789_050_000_000,
+    hash: "9".repeat(64),
+  },
+];
+const transition = {
+  prerequisite,
+  target,
+  expectedPreflightRowCount: 76,
+  localPostTargetMigrations: [target, ...later],
+};
+const uniquePostRows: AccountIssuerMigrationRowsEvidence = {
+  prerequisiteExact: 1,
+  prerequisiteTimestamp: 1,
+  prerequisiteHash: 1,
+  targetExact: 1,
+  targetTimestamp: 1,
+  targetHash: 1,
+};
+const observed = [target, ...later].map(({ createdAt, hash }) => ({
+  createdAt,
+  hash,
+}));
+
+describe("Better Auth account issuer ledger state", () => {
+  it("preserves the strict post-0086 preflight state", () => {
+    expect(
+      isExactAccountIssuerPreLedger(
+        {
+          rowCount: 76,
+          latestCreatedAt: String(prerequisite.createdAt),
+          latestHash: prerequisite.hash,
+        },
+        {
+          ...uniquePostRows,
+          targetExact: 0,
+          targetTimestamp: 0,
+          targetHash: 0,
+        },
+        transition,
+      ),
+    ).toBe(true);
+
+    expect(
+      isExactAccountIssuerPreLedger(
+        {
+          rowCount: 77,
+          latestCreatedAt: String(prerequisite.createdAt),
+          latestHash: prerequisite.hash,
+        },
+        { ...uniquePostRows, targetExact: 0, targetTimestamp: 0, targetHash: 0 },
+        transition,
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["the 0087 target", 0],
+    ["a valid 0088 head", 1],
+    ["a valid 0089 head", 2],
+  ])("accepts %s", (_description, latestIndex) => {
+    const latest = transition.localPostTargetMigrations[latestIndex]!;
+    expect(
+      isExactAccountIssuerPostLedger(
+        {
+          rowCount: 77 + latestIndex,
+          latestCreatedAt: String(latest.createdAt),
+          latestHash: latest.hash,
+        },
+        uniquePostRows,
+        observed.slice(0, latestIndex + 1),
+        transition,
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["missing target", { targetExact: 0 }],
+    ["duplicate target", { targetExact: 2 }],
+    ["target timestamp conflict", { targetTimestamp: 2 }],
+    ["target hash conflict", { targetHash: 2 }],
+    ["prerequisite timestamp conflict", { prerequisiteTimestamp: 2 }],
+  ])("rejects %s", (_description, override) => {
+    expect(
+      isExactAccountIssuerPostLedger(
+        {
+          rowCount: 79,
+          latestCreatedAt: String(later[1]!.createdAt),
+          latestHash: later[1]!.hash,
+        },
+        { ...uniquePostRows, ...override },
+        observed,
+        transition,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a ledger behind 0087, an unknown head, and a missing intermediate", () => {
+    expect(
+      isExactAccountIssuerPostLedger(
+        {
+          rowCount: 76,
+          latestCreatedAt: String(prerequisite.createdAt),
+          latestHash: prerequisite.hash,
+        },
+        uniquePostRows,
+        [],
+        transition,
+      ),
+    ).toBe(false);
+    expect(
+      isExactAccountIssuerPostLedger(
+        {
+          rowCount: 80,
+          latestCreatedAt: "1789999999999",
+          latestHash: "a".repeat(64),
+        },
+        uniquePostRows,
+        observed,
+        transition,
+      ),
+    ).toBe(false);
+    expect(
+      isExactAccountIssuerPostLedger(
+        {
+          rowCount: 79,
+          latestCreatedAt: String(later[1]!.createdAt),
+          latestHash: later[1]!.hash,
+        },
+        uniquePostRows,
+        [observed[0]!, observed[2]!],
+        transition,
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/db/__tests__/better-auth-account-issuer-ledger.test.ts
+++ b/apps/web/src/db/__tests__/better-auth-account-issuer-ledger.test.ts
@@ -158,4 +158,19 @@ describe("Better Auth account issuer ledger state", () => {
       ),
     ).toBe(false);
   });
+
+  it.each([78, 80])("rejects a valid suffix with malformed row count %i", (rowCount) => {
+    expect(
+      isExactAccountIssuerPostLedger(
+        {
+          rowCount,
+          latestCreatedAt: String(later[1]!.createdAt),
+          latestHash: later[1]!.hash,
+        },
+        uniquePostRows,
+        observed,
+        transition,
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/web/src/db/better-auth-account-issuer-ledger.ts
+++ b/apps/web/src/db/better-auth-account-issuer-ledger.ts
@@ -1,0 +1,104 @@
+export type AccountIssuerMigrationIdentity = {
+  tag: string;
+  createdAt: number;
+  hash: string;
+};
+
+export type AccountIssuerLedgerEvidence = {
+  rowCount: number;
+  latestCreatedAt: string | null;
+  latestHash: string | null;
+};
+
+export type AccountIssuerMigrationRowsEvidence = {
+  prerequisiteExact: number;
+  prerequisiteTimestamp: number;
+  prerequisiteHash: number;
+  targetExact: number;
+  targetTimestamp: number;
+  targetHash: number;
+};
+
+export type AccountIssuerPostTargetRow = {
+  createdAt: string | number;
+  hash: string;
+};
+
+type AccountIssuerLedgerTransition = {
+  prerequisite: AccountIssuerMigrationIdentity;
+  target: AccountIssuerMigrationIdentity;
+  expectedPreflightRowCount: number;
+  localPostTargetMigrations: AccountIssuerMigrationIdentity[];
+};
+
+function identityMatches(
+  observed: AccountIssuerPostTargetRow,
+  expected: AccountIssuerMigrationIdentity,
+): boolean {
+  return (
+    Number(observed.createdAt) === expected.createdAt &&
+    observed.hash === expected.hash
+  );
+}
+
+function identitiesAreUnique(
+  rows: AccountIssuerMigrationRowsEvidence,
+  expectedTargetRows: 0 | 1,
+): boolean {
+  return (
+    rows.prerequisiteExact === 1 &&
+    rows.prerequisiteTimestamp === 1 &&
+    rows.prerequisiteHash === 1 &&
+    rows.targetExact === expectedTargetRows &&
+    rows.targetTimestamp === expectedTargetRows &&
+    rows.targetHash === expectedTargetRows
+  );
+}
+
+export function isExactAccountIssuerPreLedger(
+  ledger: AccountIssuerLedgerEvidence | undefined,
+  rows: AccountIssuerMigrationRowsEvidence | undefined,
+  transition: AccountIssuerLedgerTransition,
+): boolean {
+  return Boolean(
+    ledger &&
+      rows &&
+      ledger.rowCount === transition.expectedPreflightRowCount &&
+      Number(ledger.latestCreatedAt) === transition.prerequisite.createdAt &&
+      ledger.latestHash === transition.prerequisite.hash &&
+      identitiesAreUnique(rows, 0),
+  );
+}
+
+export function isExactAccountIssuerPostLedger(
+  ledger: AccountIssuerLedgerEvidence | undefined,
+  rows: AccountIssuerMigrationRowsEvidence | undefined,
+  postTargetRows: AccountIssuerPostTargetRow[],
+  transition: AccountIssuerLedgerTransition,
+): boolean {
+  if (!ledger || !rows || !identitiesAreUnique(rows, 1)) return false;
+
+  const { localPostTargetMigrations, target } = transition;
+  if (
+    localPostTargetMigrations.length === 0 ||
+    localPostTargetMigrations[0]?.tag !== target.tag ||
+    !identityMatches(localPostTargetMigrations[0], target)
+  ) {
+    return false;
+  }
+
+  const latestIndex = localPostTargetMigrations.findIndex(
+    (migration) =>
+      Number(ledger.latestCreatedAt) === migration.createdAt &&
+      ledger.latestHash === migration.hash,
+  );
+  if (latestIndex < 0) return false;
+
+  const expectedRows = localPostTargetMigrations.slice(0, latestIndex + 1);
+  return (
+    postTargetRows.length === expectedRows.length &&
+    postTargetRows.every((row, index) =>
+      identityMatches(row, expectedRows[index]!),
+    )
+  );
+}

--- a/apps/web/src/db/better-auth-account-issuer-ledger.ts
+++ b/apps/web/src/db/better-auth-account-issuer-ledger.ts
@@ -96,6 +96,8 @@ export function isExactAccountIssuerPostLedger(
 
   const expectedRows = localPostTargetMigrations.slice(0, latestIndex + 1);
   return (
+    ledger.rowCount ===
+      transition.expectedPreflightRowCount + expectedRows.length &&
     postTargetRows.length === expectedRows.length &&
     postTargetRows.every((row, index) =>
       identityMatches(row, expectedRows[index]!),


### PR DESCRIPTION
Closes #8910

## Summary
- preserve the strict exact post-0086 preflight contract for the one-off 0087 transition
- accept postflight and drift states whose exact local ledger suffix starts at 0087 and ends at any valid later migration head
- reject missing intermediates, unknown later heads, and duplicate, hash-conflicting, or timestamp-conflicting 0087 identities
- expose the audited post-0087 ledger suffix in verifier evidence

## Verification
- 141 web database tests passed
- TypeScript no-emit check passed
- ESLint and diff checks passed